### PR TITLE
Switch MiXCR endpoint to memory-from-limits

### DIFF
--- a/.changeset/use-memory-from-limits-endpoint.md
+++ b/.changeset/use-memory-from-limits-endpoint.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow': patch
+---
+
+Switch MiXCR software endpoint from `main` to `memory-from-limits` for analyze step to respect block memory quota instead of using MaxRAMPercentage

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^2.5.0-13-master
       version: 2.5.0-25-master
     '@platforma-sdk/block-tools':
-      specifier: 2.6.48
-      version: 2.6.48
+      specifier: 2.6.52
+      version: 2.6.52
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -97,7 +97,7 @@ importers:
         version: 2.29.8(@types/node@25.2.0)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.48
+        version: 2.6.52
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -121,7 +121,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.48
+        version: 2.6.52
 
   model:
     dependencies:
@@ -137,7 +137,7 @@ importers:
         version: 1.2.1
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.48
+        version: 2.6.52
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.2(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.54.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -1042,6 +1042,10 @@ packages:
     resolution: {integrity: sha512-PNZfc1UrlQAXHIxMy9JkvTungXSOFNX4aBnamHE01GrKE6R0rPaapVynxdg1SgvkvFVps6bMe4ScZw4JuaePeQ==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.13.4':
+    resolution: {integrity: sha512-cwRnJWhOcLqh4E6rqS630XMw4AkumKxKyli1ujZjbhDRzE2PnXBkG6c71LyDt6chIlpWSTSgPYgd+tGOGnu2sA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/pf-driver@1.0.44':
     resolution: {integrity: sha512-gDB1jq+/mATYBrzHmUuHgoJCCfYsxFGl92+RmWMsGfT+yn3EfiEj94fTO5Cq8enpllqdYMa0N4KaOTOE1gZyIQ==}
     engines: {node: '>=22.19.0'}
@@ -1100,11 +1104,17 @@ packages:
   '@milaboratories/pl-model-common@1.23.0':
     resolution: {integrity: sha512-1uHb2pS+hWJyBKvfOlMYmjbFuWn+tNOULWj84mWASdqSjdYyHfVYbLq5esawM+dnZ2GBQIzJRbXrZYIMqH4Peg==}
 
+  '@milaboratories/pl-model-common@1.24.10':
+    resolution: {integrity: sha512-eK2EJjX+Rl1TSSpQJhh7r3POe0Jnm6em+zrR9RS/BZINpT0BmUWPJN7PAmiKYgdeqxP4rsrfL/eZGd+fJYGORg==}
+
   '@milaboratories/pl-model-common@1.24.4':
     resolution: {integrity: sha512-uOw6bFPttsuQzgakhb9U9FuVI4ir7N5Hqy4cUnGlFIJTCPvWNFoHPXDewSusvEyqdbpGsJJLO4FJMaTtMlzo0g==}
 
   '@milaboratories/pl-model-common@1.24.6':
     resolution: {integrity: sha512-FEsjVjJbsBMOvgkrgOhK6p3B7RHBGBmenoq9mfZpVYP2bVd3f557490FG0VvYXgvo9o0fwUzcNLDy3Wqv/ryhg==}
+
+  '@milaboratories/pl-model-middle-layer@1.11.12':
+    resolution: {integrity: sha512-S5W6cOyXilFascmU2p5BlFN7QjOYhvkyNe9Wsy1lZ8G8mBuW/rBdmsK6qxUQKY5ZG242o1ylEZP2w6+G7d7VOQ==}
 
   '@milaboratories/pl-model-middle-layer@1.11.5':
     resolution: {integrity: sha512-4ireMiilEaAl0G2nCn6/pf+bSui1HX6k8jRrM7XJTXgm2zh8GckaNS+WwIlJ/NOfal4LtMW05cCwXtOBGbcU/g==}
@@ -1121,6 +1131,9 @@ packages:
 
   '@milaboratories/ptabler-expression-js@1.1.16':
     resolution: {integrity: sha512-Iu7/f0M3H+Cu+6BunwUqcPDO86coHCavsgANJ8mFdCPvIiYj/du3QdaTzi9rH0YO+9n2i0aFd5+seNL2YvkbJQ==}
+
+  '@milaboratories/ptabler-expression-js@1.1.20':
+    resolution: {integrity: sha512-oQK6WRtxGP/FWhG2qAMFhduxX/5No4LUhq3Lomo2j6tjBf8PopgnmAYksYoJp1IGIoRmKXAZ3RLB/34ar1guGw==}
 
   '@milaboratories/ptabler-expression-js@1.1.9':
     resolution: {integrity: sha512-fH0gix6ObRI9/TgPk1S40EkdFLskSdh6AloNBhkedH7WyTwOmM7zmtjmp+n7TiRHzRfufqzwLOZ9TFb7qAXQRA==}
@@ -1319,6 +1332,9 @@ packages:
   '@platforma-open/milaboratories.software-mixcr@4.7.0-300-develop':
     resolution: {integrity: sha512-3MNXKJQXO8QiAi4OSNIkVWd9pClqwDWujftRb97IOaE2vd88Jvj91Er5gcZm+vVOYjkYZPMzV1b8JP0ooOI/IQ==}
 
+  '@platforma-open/milaboratories.software-ptabler.schema@1.13.13':
+    resolution: {integrity: sha512-60q83jtlKFcvon41vFkJKmizQW1xDgAk2CjAKQsGFtRBZiy8o30HRYloaatYNx7BzcPR5yDdsse9rnsbspyb5Q==}
+
   '@platforma-open/milaboratories.software-ptabler.schema@1.13.2':
     resolution: {integrity: sha512-xQ5eD6WNLL490bQY2kEH/Dz+0SE5uyLexwOQzoUpKhBqdYb4eIKGA2NnZ9SDOgfDoiNFzTeYGQhuI+R3W6P0Og==}
 
@@ -1359,6 +1375,10 @@ packages:
     resolution: {integrity: sha512-mxWnHQX1uxLh+LFEPqT5m3HAGxVhKYUoKkirRxJMRQSjIVSIJNxv//AnPbwdR0sYttzwu3FKXDLPFw7l/jSQ4A==}
     hasBin: true
 
+  '@platforma-sdk/block-tools@2.6.52':
+    resolution: {integrity: sha512-AUUjomHVPwUVspRkkacFB7PifGnYT4Oudclr+D32ovRpHorA6jhuQrKiE54iZPaTBIqYsW2ArL232xbsacZwKg==}
+    hasBin: true
+
   '@platforma-sdk/blocks-deps-updater@2.0.1':
     resolution: {integrity: sha512-k5BRlBSjsu48v9/u4386Jd7MLv8a0+FMZhAn7vEIc7NR3rTNf/KX8mlFcP/XxNVjLFOGXb9jiR7EJrBZKXvN0g==}
     hasBin: true
@@ -1383,6 +1403,9 @@ packages:
 
   '@platforma-sdk/model@1.53.15':
     resolution: {integrity: sha512-OUx+tdT/a1B6DlsWu9N4FX40KJFiNKLoSZi8y62HkoUp42CKqa7tX/zUxx4/suTNfsZfqecnAt7Io+7w6sa8JQ==}
+
+  '@platforma-sdk/model@1.54.10':
+    resolution: {integrity: sha512-lZQUKyHezEZUQfjC0hft2DSekyo6NULra3/WqiMIqGTUpwpl2FoV8kt9a3hnYbue9K8zVj9eBr7Byeus7m6gig==}
 
   '@platforma-sdk/package-builder@3.11.4':
     resolution: {integrity: sha512-t7SG8DZeRhawmGvSjAf67E7BH2VtRg4mVqB5GXid+gZSPVR76YLeLVf6FN2Be55pQjHK0blb7YYqFUBB5ykdmA==}
@@ -5769,6 +5792,8 @@ snapshots:
 
   '@milaboratories/helpers@1.13.3': {}
 
+  '@milaboratories/helpers@1.13.4': {}
+
   '@milaboratories/pf-driver@1.0.44(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.24.6)':
     dependencies:
       '@milaboratories/pframes-rs-node': 1.1.2
@@ -5948,6 +5973,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
+  '@milaboratories/pl-model-common@1.24.10':
+    dependencies:
+      '@milaboratories/pl-error-like': 1.12.8
+      canonicalize: 2.1.0
+      zod: 3.23.8
+
   '@milaboratories/pl-model-common@1.24.4':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.6
@@ -5958,6 +5989,14 @@ snapshots:
     dependencies:
       '@milaboratories/pl-error-like': 1.12.8
       canonicalize: 2.1.0
+      zod: 3.23.8
+
+  '@milaboratories/pl-model-middle-layer@1.11.12':
+    dependencies:
+      '@milaboratories/pl-model-common': 1.24.10
+      '@platforma-sdk/model': 1.54.10
+      es-toolkit: 1.44.0
+      utility-types: 3.11.0
       zod: 3.23.8
 
   '@milaboratories/pl-model-middle-layer@1.11.5':
@@ -5993,6 +6032,10 @@ snapshots:
   '@milaboratories/ptabler-expression-js@1.1.16':
     dependencies:
       '@platforma-open/milaboratories.software-ptabler.schema': 1.13.9
+
+  '@milaboratories/ptabler-expression-js@1.1.20':
+    dependencies:
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.13.13
 
   '@milaboratories/ptabler-expression-js@1.1.9':
     dependencies:
@@ -6289,6 +6332,10 @@ snapshots:
 
   '@platforma-open/milaboratories.software-mixcr@4.7.0-300-develop': {}
 
+  '@platforma-open/milaboratories.software-ptabler.schema@1.13.13':
+    dependencies:
+      '@milaboratories/pl-model-common': 1.24.10
+
   '@platforma-open/milaboratories.software-ptabler.schema@1.13.2':
     dependencies:
       '@milaboratories/pl-model-common': 1.23.0
@@ -6345,6 +6392,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@platforma-sdk/block-tools@2.6.52':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@milaboratories/pl-http': 1.2.3
+      '@milaboratories/pl-model-common': 1.24.10
+      '@milaboratories/pl-model-middle-layer': 1.11.12
+      '@milaboratories/resolve-helper': 1.1.2
+      '@milaboratories/ts-helpers': 1.7.2
+      '@milaboratories/ts-helpers-oclif': 1.1.37
+      '@oclif/core': 4.8.0
+      '@platforma-sdk/blocks-deps-updater': 2.0.1
+      canonicalize: 2.1.0
+      lru-cache: 11.2.5
+      mime-types: 2.1.35
+      tar: 7.5.7
+      undici: 7.16.0
+      yaml: 2.8.2
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - aws-crt
+
   '@platforma-sdk/blocks-deps-updater@2.0.1':
     dependencies:
       yaml: 2.8.2
@@ -6386,6 +6454,18 @@ snapshots:
       '@milaboratories/pl-error-like': 1.12.8
       '@milaboratories/pl-model-common': 1.24.6
       '@milaboratories/ptabler-expression-js': 1.1.16
+      canonicalize: 2.1.0
+      es-toolkit: 1.44.0
+      fast-json-patch: 3.1.1
+      utility-types: 3.11.0
+      zod: 3.23.8
+
+  '@platforma-sdk/model@1.54.10':
+    dependencies:
+      '@milaboratories/helpers': 1.13.4
+      '@milaboratories/pl-error-like': 1.12.8
+      '@milaboratories/pl-model-common': 1.24.10
+      '@milaboratories/ptabler-expression-js': 1.1.20
       canonicalize: 2.1.0
       es-toolkit: 1.44.0
       fast-json-patch: 3.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.54.1
   '@platforma-sdk/tengo-builder': 2.4.17
   '@platforma-sdk/package-builder': 3.11.4
-  '@platforma-sdk/block-tools': 2.6.48
+  '@platforma-sdk/block-tools': 2.6.52
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.54.3
   '@milaboratories/helpers': 1.13.3

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -18,7 +18,7 @@ json := import("json")
 
 self.defineOutputs(["qcIGHeavy", "qcIGLight", "reportsIGHeavy", "reportsIGLight", "logsIGHeavy", "logsIGLight", "clonotypesTableTsv", "clnsIGHeavy", "clnsIGLight"])
 
-mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:main")
+mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:memory-from-limits")
 
 progressPrefix := "[==PROGRESS==]"
 


### PR DESCRIPTION
## Summary

- Switch MiXCR software endpoint from `main` to `memory-from-limits` for the analyze step (`mixcr-analyze.tpl.tengo`)
- The `main` endpoint uses `-XX:MaxRAMPercentage=80.0` which ignores the block's memory quota and takes 80% of visible system RAM — can cause OOM when Java sees less RAM than physical total (e.g. ~124GB visible on a 256GB Windows machine)
- The `memory-from-limits` endpoint derives `-Xms` from the actual allocated memory quota, consistent with `mixcr-clonotyping` block behavior
- `export-report` left on `main` endpoint (lightweight operation, matches clonotyping convention)
- Updated `block-tools` to 2.6.52 (CI requirement)

## Test plan

- [ ] Run scFv clonotyping with large dataset to verify analyze step completes without OOM
- [ ] Verify `mixcrMem` setting correctly controls Java heap allocation