### PR TITLE
Add Preview run mode for quick settings validation

### DIFF
--- a/.changeset/dry-run-preview-mode.md
+++ b/.changeset/dry-run-preview-mode.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui": patch
+---
+
+Add Preview run mode to quickly validate settings on a fraction of reads before committing to a full analysis

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -2,7 +2,7 @@
 import type { PlRef } from '@platforma-sdk/model';
 import type { ListOption } from '@platforma-sdk/ui-vue';
 import { PlAccordionSection, PlAlert, PlBtnGroup, PlCheckbox, PlDropdown, PlDropdownMulti, PlDropdownRef, PlNumberField, PlSectionSeparator, PlTextArea, PlTextField } from '@platforma-sdk/ui-vue';
-import { computed, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useApp } from '../app';
 import { parseFasta } from '../utils/fastaValidator';
 import { validateFullScFv, validateLibrarySequence, validateSeparateChain, validateLinker, validateHinge } from '../utils/sequenceValidator';
@@ -132,6 +132,16 @@ watch(stopCodonSelection, (selected) => {
 });
 
 const DRY_RUN_READS = 100_000;
+const lastLimitInput = ref(app.model.args.limitInput);
+
+watch(
+  () => app.model.args.limitInput,
+  (newLimit) => {
+    if ((newLimit ?? 0) > 0) {
+      lastLimitInput.value = newLimit;
+    }
+  },
+);
 
 const runModeOptions: ListOption<'dry' | 'full'>[] = [
   { label: 'Preview', value: 'dry' },
@@ -139,10 +149,10 @@ const runModeOptions: ListOption<'dry' | 'full'>[] = [
 ];
 
 const runMode = computed({
-  get: () => (app.model.args.limitInput !== undefined ? 'dry' : 'full'),
+  get: () => ((app.model.args.limitInput ?? 0) > 0 ? 'dry' : 'full'),
   set: (value: 'dry' | 'full') => {
     if (value === 'dry') {
-      app.model.args.limitInput = DRY_RUN_READS;
+      app.model.args.limitInput = lastLimitInput.value ?? DRY_RUN_READS;
     } else {
       app.model.args.limitInput = undefined;
     }

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -148,16 +148,24 @@ const runModeOptions: ListOption<'dry' | 'full'>[] = [
   { label: 'Full run', value: 'full' },
 ];
 
-const runMode = computed({
-  get: () => ((app.model.args.limitInput ?? 0) > 0 ? 'dry' : 'full'),
-  set: (value: 'dry' | 'full') => {
-    if (value === 'dry') {
-      app.model.args.limitInput = lastLimitInput.value ?? DRY_RUN_READS;
-    } else {
-      app.model.args.limitInput = undefined;
-    }
-  },
+const runMode = ref<'dry' | 'full'>((app.model.args.limitInput ?? 0) > 0 ? 'dry' : 'full');
+
+watch(runMode, (value) => {
+  if (value === 'dry') {
+    app.model.args.limitInput = lastLimitInput.value ?? DRY_RUN_READS;
+  } else {
+    app.model.args.limitInput = undefined;
+  }
 });
+
+watch(
+  () => app.model.args.input,
+  () => {
+    lastLimitInput.value = undefined;
+    runMode.value = 'dry';
+    app.model.args.limitInput = DRY_RUN_READS;
+  },
+);
 
 const heavyValidation = computed(() => {
   if (app.model.args.customRefMode === 'separate') {
@@ -606,8 +614,10 @@ heavy-seq + linker + light-seq (or reverse)"
     v-if="runMode === 'dry'"
     v-model="app.model.args.limitInput"
     label="Reads per sample limit"
+    :clearable="true"
     :minValue="1"
     :validate="(v) => (Number.isInteger(v) ? undefined : 'Value must be an integer')"
+    :error-message="app.model.args.limitInput == null ? 'Enter a number of reads to use per sample' : undefined"
   >
     <template #tooltip>
       Number of reads to use per sample in the preview run. Recommended: 100,000 for bulk data.

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -131,6 +131,24 @@ watch(stopCodonSelection, (selected) => {
   app.model.args.stopCodonReplacements = Object.keys(next).length > 0 ? next : undefined;
 });
 
+const DRY_RUN_READS = 100_000;
+
+const runModeOptions: ListOption<'dry' | 'full'>[] = [
+  { label: 'Preview', value: 'dry' },
+  { label: 'Full run', value: 'full' },
+];
+
+const runMode = computed({
+  get: () => (app.model.args.limitInput !== undefined ? 'dry' : 'full'),
+  set: (value: 'dry' | 'full') => {
+    if (value === 'dry') {
+      app.model.args.limitInput = DRY_RUN_READS;
+    } else {
+      app.model.args.limitInput = undefined;
+    }
+  },
+});
+
 const heavyValidation = computed(() => {
   if (app.model.args.customRefMode === 'separate') {
     const raw = (app.model.args.heavyChainSequence ?? '').trim();
@@ -568,6 +586,24 @@ heavy-seq + linker + light-seq (or reverse)"
     </template>
   </PlTextArea>
 
+  <PlBtnGroup v-model="runMode" :options="runModeOptions" label="Run mode">
+    <template #tooltip>
+      Preview — runs the analysis on a small fraction of reads per sample. Use it to check that settings are correct and results look reasonable before launching a full run, which may take much longer.
+    </template>
+  </PlBtnGroup>
+
+  <PlNumberField
+    v-if="runMode === 'dry'"
+    v-model="app.model.args.limitInput"
+    label="Reads per sample limit"
+    :minValue="1"
+    :validate="(v) => (Number.isInteger(v) ? undefined : 'Value must be an integer')"
+  >
+    <template #tooltip>
+      Number of reads to use per sample in the preview run. Recommended: 100,000 for bulk data.
+    </template>
+  </PlNumberField>
+
   <PlAccordionSection label="Advanced Settings">
     <PlSectionSeparator>MiXCR Settings</PlSectionSeparator>
     <PlDropdown
@@ -583,12 +619,6 @@ heavy-seq + linker + light-seq (or reverse)"
         </ul>
       </template>
     </PlDropdown>
-    <PlNumberField
-      v-model="app.model.args.limitInput"
-      label="Take only this number of reads into analysis"
-      :clearable="true"
-      :minValue="1"
-    />
     <PlSectionSeparator>Stop codon replacement</PlSectionSeparator>
     <PlDropdownMulti
       v-model="stopCodonSelection"


### PR DESCRIPTION
Replaces the buried "limit input reads" field in Advanced Settings with a **Preview / Full run** toggle.

Preview runs the analysis on 100,000 reads per sample — enough to validate settings and catch errors before committing to a full run.

**Edge cases handled:**
- Clearing the reads field stays in Preview; an inline error prompts re-entry
- Toggling Preview → Full run → Preview restores the user's custom limit
- Selecting a new dataset resets to Preview with the 100,000-read default