### PR TITLE
Fix cross-project deduplication for aggregation and QC report

### DIFF
--- a/.changeset/dedup-fixes.md
+++ b/.changeset/dedup-fixes.md
@@ -1,0 +1,11 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow': minor
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping': minor
+---
+
+Fix cross-project deduplication for aggregation and QC report
+
+- Add `anonymize: true` to aggregation processColumn
+- Anonymize QC report inputs and deanonymize output TSV
+- Move CPU/memory allocation params to metaExtra in analyze processColumn
+- Add `hash_override` to all 5 structural templates

--- a/workflow/src/agg-clones.tpl.tengo
+++ b/workflow/src/agg-clones.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override B4E8C2DA-6F3E-4B9A-87D4-E0F5A1B2C3D6
+
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")

--- a/workflow/src/deanonymization.tpl.tengo
+++ b/workflow/src/deanonymization.tpl.tengo
@@ -1,0 +1,70 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+smart := import("@platforma-sdk/workflow-tengo:smart")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+maps := import("@platforma-sdk/workflow-tengo:maps")
+
+self.defineOutputs("deanonimizedTsv")
+
+self.awaitState("clusteringResult", "ResourceReady")
+self.awaitState("mapping", "ResourceReady")
+
+/**
+ * Builds a when/then/otherwise expression to replace values in a column based on a mapping.
+ * @param colExpr - pt column expression
+ * @param mapping - map from anonymized values (oldVal) to original values (newVal)
+ * @returns pt expression with value replacements
+ */
+buildReplaceExpression := func(colExpr, mapping) {
+	if len(mapping) == 0 {
+		return colExpr
+	}
+
+	whenExpr := undefined
+	maps.forEach(mapping, func(oldVal, newVal) {
+		condition := colExpr.eq(pt.lit(oldVal))
+		if is_undefined(whenExpr) {
+			whenExpr = pt.when(condition).then(pt.lit(newVal))
+		} else {
+			whenExpr = whenExpr.when(condition).then(pt.lit(newVal))
+		}
+	})
+
+	return whenExpr.otherwise(colExpr)
+}
+
+self.body(func(args) {
+	// Get mapping JSON
+	mappingJson := undefined
+	if smart.isResource(args.mapping) {
+		mappingJson = args.mapping.getDataAsJson()
+	} else if is_map(args.mapping) {
+		mappingJson = args.mapping
+	} else {
+		mappingResource := smart.resource(args.mapping)
+		mappingJson = mappingResource.getDataAsJson()
+	}
+
+	// Process TSV file
+	deanonimizedTsv := args.clusteringResult
+	if !is_undefined(deanonimizedTsv) {
+		wf := pt.workflow().mem("8GiB").cpu(2)
+
+		df := wf.frame(deanonimizedTsv, {
+			xsvType: "tsv",
+			inferSchema: false
+		})
+
+		// Replace anonymized sampleId values with real ones
+		df = df.withColumns(
+			buildReplaceExpression(pt.col("sampleId"), mappingJson).alias("sampleId")
+		)
+
+		df.save("result.tsv")
+		ptResult := wf.run()
+		deanonimizedTsv = ptResult.getFile("result.tsv")
+	}
+
+	return {
+		deanonimizedTsv: deanonimizedTsv
+	}
+})

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override D6A0E4FC-8B5A-4DBC-A9F6-A2B7C3D4E5F8
+
 self := import("@platforma-sdk/workflow-tengo:tpl")
 smart := import("@platforma-sdk/workflow-tengo:smart")
 ll := import("@platforma-sdk/workflow-tengo:ll")
@@ -7,15 +9,13 @@ pcolumn := import("@platforma-sdk/workflow-tengo:pframes.pcolumn")
 times := import("times")
 text := import("text")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
-xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 pt := import("@platforma-sdk/workflow-tengo:pt")
-qcReportColumns := import(":qc-report-columns")
 
 json := import("json")
 
-self.defineOutputs("qcReportTable")
+self.defineOutputs("rawTsv")
 
 mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:main")
 
@@ -305,20 +305,8 @@ self.body(func(inputs) {
     
     tsvFile := wfResult.getFile("qc-report-processed.tsv")
 
-    // Only generate column spec for chains that actually have data
-    qcReportColumnsResult := qcReportColumns(hasUmi, sampleIdAxisSpec, chainsWithData)
-    reportColumnsSpec := qcReportColumnsResult.reportColumnsSpec
-
-    qcReportTable := xsv.importFile(
-		tsvFile,
-		"tsv",
-		reportColumnsSpec,
-		{ cpu: 1, mem: "16GiB" }
-	)
-
-    
     return {
-        qcReportTable: qcReportTable
+        rawTsv: tsvFile
     }
 })
 

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override A3F7B1C9-5E2D-4A8F-96C3-D9E4F0A1B2C5
+
 // mixcr analyze
 
 self := import("@platforma-sdk/workflow-tengo:tpl")

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -13,8 +13,11 @@ llPFrames := import("@platforma-sdk/workflow-tengo:pframes.ll")
 pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
 pUtil := import("@platforma-sdk/workflow-tengo:pframes.util")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
+anonymize := import("@platforma-sdk/workflow-tengo:anonymize")
+xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 
 mixcrExports := import(":mixcr-exports")
+qcReportColumnsLib := import(":qc-report-columns")
 
 json := import("json")
 text := import("text")
@@ -24,6 +27,7 @@ mixcrAnalyzeTpl := assets.importTemplate(":mixcr-analyze")
 aggClonesTpl := assets.importTemplate(":agg-clones")
 exportReportTpl := assets.importTemplate(":export-report")
 stopCodonReplaceTpl := assets.importTemplate(":stop-codon-replace")
+deanonymizationTpl := assets.importTemplate(":deanonymization")
 
 self.awaitState("InputsLocked")
 self.awaitState("inputSpec", "ResourceReady")
@@ -412,11 +416,14 @@ self.body(func(inputs) {
 				referenceLibraryHeavy: inputs.referenceLibraryHeavy,
 				referenceLibraryLight: inputs.referenceLibraryLight,
 				truncateFR4: truncateFR4,
+				cloneClusteringMode: inputs.cloneClusteringMode
+			},
+
+			metaExtra: {
 				mixcrCpu: inputs.mixcrCpu,
 				mixcrMem: inputs.mixcrMem,
 				assembleScfvCpu: inputs.assembleScfvCpu,
-				assembleScfvMem: inputs.assembleScfvMem,
-				cloneClusteringMode: inputs.cloneClusteringMode
+				assembleScfvMem: inputs.assembleScfvMem
 			}
 		}
 	)
@@ -467,7 +474,7 @@ self.body(func(inputs) {
 		aggClonesTpl,
 		aggregationOutputs,
 		{
-			aggregate: ["pl7.app/sampleId"],
+			aggregate: [{ name: "pl7.app/sampleId", anonymize: true }],
 			extra: {
 				mainAbundanceColumnNormalized: mainAbundanceColumnNormalized,
 				mainAbundanceColumnUnnormalized: mainAbundanceColumnUnnormalized,
@@ -489,18 +496,40 @@ self.body(func(inputs) {
 	sampleIdAxisSpec := inputSpec.axesSpec[0]
 	hasUmi := inputs.hasUMIs
 	chains := ["IGHeavy", "IGLight"]
-	
-	qcReportTable := render.create(exportReportTpl, {
+
+	// Anonymize sample-keyed ResourceMaps for QC report dedup
+	anonResult := anonymize.anonymizePKeys({
 		clnsDataHeavy: mixcrResults.outputData("clnsIGHeavy"),
 		clnsDataLight: mixcrResults.outputData("clnsIGLight"),
+		clonotypeTablesData: clonotypeTableData
+	}, [0])
+
+	qcReportRender := render.create(exportReportTpl, {
+		clnsDataHeavy: anonResult.result["clnsDataHeavy"],
+		clnsDataLight: anonResult.result["clnsDataLight"],
 		sampleIdAxisSpec: sampleIdAxisSpec,
 		chains: chains,
-		clonotypeTablesData: clonotypeTableData,
+		clonotypeTablesData: anonResult.result["clonotypeTablesData"],
 		hasUmi: hasUmi,
-		suppressLight: lightSuppressed, 
+		suppressLight: lightSuppressed,
 		lightLibrary: inputs.referenceLibraryLight,
 		heavyLibrary: inputs.referenceLibraryHeavy
 	})
+
+	// Deanonymize QC report raw TSV
+	deanonResult := render.createEphemeral(deanonymizationTpl, {
+		mapping: anonResult.mapping,
+		clusteringResult: qcReportRender.output("rawTsv")
+	})
+
+	// Import deanonymized TSV into PFrame
+	qcReportColumns := qcReportColumnsLib(hasUmi, sampleIdAxisSpec, chains)
+	qcReportTable := xsv.importFile(
+		deanonResult.output("deanonimizedTsv"),
+		"tsv",
+		qcReportColumns.reportColumnsSpec,
+		{ cpu: 1, mem: "16GiB" }
+	)
 
 	result := {}
 	for chain in ["IGHeavy", "IGLight"] {
@@ -515,7 +544,7 @@ self.body(func(inputs) {
 	}
 	result["clonotypes"] = clonotypes
 	result["clonotypeTables"] = clonotypeTablesOutputs.build()
-	result["qcReportTable"] = qcReportTable.output("qcReportTable")
+	result["qcReportTable"] = qcReportTable
 
 	return result
 })

--- a/workflow/src/repseqio-library.tpl.tengo
+++ b/workflow/src/repseqio-library.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override E7B1F5AD-9C6B-4ECD-B0A7-B3C8D4E5F6A9
+
 // repseqio-library template for generating reference library from V and J FASTA files
 
 self := import("@platforma-sdk/workflow-tengo:tpl")

--- a/workflow/src/stop-codon-replace.tpl.tengo
+++ b/workflow/src/stop-codon-replace.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override C5F9D3EB-7A4F-4CAB-98E5-F1A6B2C3D4E7
+
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")


### PR DESCRIPTION
## Summary
- Add `anonymize: true` to aggregation processColumn
- Anonymize QC report inputs (`clnsDataHeavy`, `clnsDataLight`, `clonotypeTablesData`) before structural `render.create`; deanonymize output TSV via ephemeral PTabler
- Move `mixcrCpu`/`mixcrMem`/`assembleScfvCpu`/`assembleScfvMem` from `extra` to `metaExtra` in analyze processColumn (resource allocation no longer breaks dedup)
- Add `hash_override` to all 5 structural templates

## Test plan
- [x] Build succeeds
- [ ] No workflow tests in this block (test file is a placeholder)