### PR TITLE
Migrate to BlockModelV3 and add Preview/Dry run mode

### DIFF
--- a/.changeset/blockmodelv3-and-preview-mode.md
+++ b/.changeset/blockmodelv3-and-preview-mode.md
@@ -1,7 +1,7 @@
 ---
-'@platforma-open/milaboratories.mixcr-scfv-clonotyping.model': minor
-'@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui': minor
-'@platforma-open/milaboratories.mixcr-scfv-clonotyping': minor
+"@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow": minor
+"@platforma-open/milaboratories.mixcr-scfv-clonotyping.model": minor
+"@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui": minor
 ---
 
 Migrate to BlockModelV3 with `DataModelBuilder` and add Preview / Dry run mode (100,000 reads per sample) so users can verify settings before launching a full analysis.

--- a/.changeset/blockmodelv3-and-preview-mode.md
+++ b/.changeset/blockmodelv3-and-preview-mode.md
@@ -1,0 +1,7 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.model': minor
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui': minor
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping': minor
+---
+
+Migrate to BlockModelV3 with `DataModelBuilder` and add Preview / Dry run mode (100,000 reads per sample) so users can verify settings before launching a full analysis.

--- a/.changeset/fix-runmode-watcher-null-check.md
+++ b/.changeset/fix-runmode-watcher-null-check.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui': patch
+---
+
+Use `== null` in the runMode watcher so a cleared read-limit field seeds the preview default

--- a/.changeset/fix-runmode-watcher-null-check.md
+++ b/.changeset/fix-runmode-watcher-null-check.md
@@ -1,5 +1,0 @@
----
-'@platforma-open/milaboratories.mixcr-scfv-clonotyping.ui': patch
----
-
-Use `== null` in the runMode watcher so a cleared read-limit field seeds the preview default

--- a/model/package.json
+++ b/model/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@platforma-sdk/model": "catalog:"
+    "@platforma-sdk/model": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@milaboratories/ts-builder": "catalog:",

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,11 +1,14 @@
 import type { InferOutputsType, PlDataTableStateV2, PlRef } from '@platforma-sdk/model';
 import {
-  BlockModel,
+  BlockModelV3,
+  DataModelBuilder,
   createPlDataTableV2,
   createPlDataTableStateV2,
   isPColumnSpec,
   parseResourceMap,
 } from '@platforma-sdk/model';
+
+export * from './reports';
 
 export type CloneClusteringMode = 'relaxed' | 'default' | 'off';
 export type StopCodonType = 'amber' | 'ochre' | 'opal';
@@ -61,14 +64,28 @@ export type UiState = {
   tableState: PlDataTableStateV2;
 };
 
+export type BlockData = BlockArgs & {
+  tableState: PlDataTableStateV2;
+  runMode: 'dry' | 'full';
+};
+
+type LegacyUiState = {
+  tableState: PlDataTableStateV2;
+};
+
 export const ProgressPrefix = '[==PROGRESS==]';
 
 export const ProgressPattern
   = /(?<stage>[^:]*):(?: *(?<progress>[0-9.]+)%)?(?: *ETA: *(?<eta>.+))?/;
 
-export const model = BlockModel.create()
-
-  .withArgs<BlockArgs>({
+const dataModel = new DataModelBuilder()
+  .from<BlockData>('v1')
+  .upgradeLegacy<BlockArgs, LegacyUiState>(({ args, uiState }) => ({
+    ...args,
+    tableState: uiState.tableState,
+    runMode: (args.limitInput ?? 0) > 0 ? 'dry' : 'full',
+  }))
+  .init(() => ({
     defaultBlockLabel: 'Select Dataset',
     customBlockLabel: '',
     heavyAssemblingFeature: 'FR1:FR4',
@@ -82,28 +99,62 @@ export const model = BlockModel.create()
     assembleScfvMem: 64,
     assembleScfvCpu: 4,
     cloneClusteringMode: 'relaxed',
-  })
-  .withUiState<UiState>({
     tableState: createPlDataTableStateV2(),
-  })
+    runMode: 'full',
+  }));
 
-  .argsValid((ctx) => {
-    const mode = ctx.args.customRefMode ?? 'builtin';
-    const speciesOk = mode === 'builtin' ? ctx.args.species !== undefined : true;
+export const model = BlockModelV3.create(dataModel)
+
+  .args((data) => {
+    const mode = data.customRefMode ?? 'builtin';
+    const speciesOk = mode === 'builtin' ? data.species !== undefined : true;
     const skipLightTagPattern = (
-      (mode === 'scFv' || mode === 'separate') && (ctx.args.imputeLight === true)
+      (mode === 'scFv' || mode === 'separate') && (data.imputeLight === true)
     ) || (
       // also skip if a light impute sequence is already present (avoids transient race)
-      (mode === 'scFv' || mode === 'separate') && typeof ctx.args.lightImputeSequence === 'string' && ctx.args.lightImputeSequence.length > 0
+      (mode === 'scFv' || mode === 'separate') && typeof data.lightImputeSequence === 'string' && data.lightImputeSequence.length > 0
     );
-    return (
-      ctx.args.input !== undefined
-      && speciesOk
-      && ctx.args.linker !== undefined
-      && ctx.args.hinge !== undefined
-      && ctx.args.heavyTagPattern !== undefined
-      && (skipLightTagPattern ? true : ctx.args.lightTagPattern !== undefined)
-    );
+
+    if (!data.input) throw new Error('Input dataset is required');
+    if (!speciesOk) throw new Error('Species is required');
+    if (!data.linker) throw new Error('Linker is required');
+    if (data.hinge === undefined) throw new Error('Hinge is required');
+    if (!data.heavyTagPattern) throw new Error('Heavy tag pattern is required');
+    if (!skipLightTagPattern && !data.lightTagPattern) throw new Error('Light tag pattern is required');
+    if (data.runMode === 'dry' && data.limitInput == null) throw new Error('Read limit is required for Preview mode');
+
+    return {
+      defaultBlockLabel: data.defaultBlockLabel,
+      customBlockLabel: data.customBlockLabel,
+      title: data.title,
+      input: data.input,
+      species: data.species,
+      linker: data.linker,
+      hinge: data.hinge,
+      order: data.order,
+      heavyTagPattern: data.heavyTagPattern,
+      heavyAssemblingFeature: data.heavyAssemblingFeature,
+      lightTagPattern: data.lightTagPattern,
+      lightAssemblingFeature: data.lightAssemblingFeature,
+      limitInput: data.runMode === 'dry' ? data.limitInput : undefined,
+      customRefMode: data.customRefMode,
+      scFvSequence: data.scFvSequence,
+      heavyChainSequence: data.heavyChainSequence,
+      lightChainSequence: data.lightChainSequence,
+      lightImputeSequence: data.lightImputeSequence,
+      imputeLight: data.imputeLight,
+      heavyVGenes: data.heavyVGenes,
+      heavyJGenes: data.heavyJGenes,
+      lightVGenes: data.lightVGenes,
+      lightJGenes: data.lightJGenes,
+      mixcrMem: data.mixcrMem,
+      mixcrCpu: data.mixcrCpu,
+      assembleScfvMem: data.assembleScfvMem,
+      assembleScfvCpu: data.assembleScfvCpu,
+      cloneClusteringMode: data.cloneClusteringMode,
+      stopCodonTypes: data.stopCodonTypes,
+      stopCodonReplacements: data.stopCodonReplacements,
+    };
   })
 
   .retentiveOutput('inputOptions', (ctx) => {
@@ -123,7 +174,7 @@ export const model = BlockModel.create()
   })
 
   .output('sampleLabels', (ctx): Record<string, string> | undefined => {
-    const inputRef = ctx.args.input;
+    const inputRef = ctx.data.input;
     if (inputRef === undefined) return undefined;
 
     const spec = ctx.resultPool.getPColumnSpecByRef(inputRef);
@@ -198,7 +249,7 @@ export const model = BlockModel.create()
     if (pCols === undefined) {
       return undefined;
     }
-    return createPlDataTableV2(ctx, pCols, ctx.uiState.tableState);
+    return createPlDataTableV2(ctx, pCols, ctx.data.tableState);
   })
 
   .sections((_) => [
@@ -208,8 +259,8 @@ export const model = BlockModel.create()
 
   .title(() => 'MiXCR scFv Alignment')
 
-  .subtitle((ctx) => ctx.args.customBlockLabel || ctx.args.defaultBlockLabel || '')
+  .subtitle((ctx) => ctx.data.customBlockLabel || ctx.data.defaultBlockLabel || '')
 
-  .done(2);
+  .done();
 
 export type BlockOutputs = InferOutputsType<typeof model>;

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,4 +1,4 @@
-import type { InferOutputsType, PlDataTableStateV2, PlRef } from '@platforma-sdk/model';
+import type { InferHrefType, InferOutputsType, PlDataTableStateV2, PlRef } from '@platforma-sdk/model';
 import {
   BlockModelV3,
   DataModelBuilder,
@@ -7,7 +7,9 @@ import {
   isPColumnSpec,
   parseResourceMap,
 } from '@platforma-sdk/model';
+import { ProgressPrefix } from './progress';
 
+export * from './progress';
 export * from './reports';
 
 export type CloneClusteringMode = 'relaxed' | 'default' | 'off';
@@ -73,11 +75,6 @@ type LegacyUiState = {
   tableState: PlDataTableStateV2;
 };
 
-export const ProgressPrefix = '[==PROGRESS==]';
-
-export const ProgressPattern
-  = /(?<stage>[^:]*):(?: *(?<progress>[0-9.]+)%)?(?: *ETA: *(?<eta>.+))?/;
-
 const dataModel = new DataModelBuilder()
   .from<BlockData>('v1')
   .upgradeLegacy<BlockArgs, LegacyUiState>(({ args, uiState }) => ({
@@ -103,7 +100,7 @@ const dataModel = new DataModelBuilder()
     runMode: 'full',
   }));
 
-export const model = BlockModelV3.create(dataModel)
+export const platforma = BlockModelV3.create(dataModel)
 
   .args((data) => {
     const mode = data.customRefMode ?? 'builtin';
@@ -263,4 +260,5 @@ export const model = BlockModelV3.create(dataModel)
 
   .done();
 
-export type BlockOutputs = InferOutputsType<typeof model>;
+export type BlockOutputs = InferOutputsType<typeof platforma>;
+export type Href = InferHrefType<typeof platforma>;

--- a/model/src/progress.ts
+++ b/model/src/progress.ts
@@ -1,0 +1,4 @@
+export const ProgressPrefix = '[==PROGRESS==]';
+
+export const ProgressPattern
+  = /(?<stage>[^:]*):(?: *(?<progress>[0-9.]+)%)?(?: *ETA: *(?<eta>.+))?/;

--- a/model/src/reports.ts
+++ b/model/src/reports.ts
@@ -1,0 +1,223 @@
+import { z } from 'zod';
+
+export const ImmuneChain = z.union([
+  z.literal(''),
+  z.literal('TRA'),
+  z.literal('TRAD'),
+  z.literal('TRB'),
+  z.literal('TRG'),
+  z.literal('TRD'),
+  z.literal('IGH'),
+  z.literal('IGK'),
+  z.literal('IGL'),
+]);
+
+export type ImmuneChain = z.infer<typeof ImmuneChain>;
+
+// Fixed ordering for immune chains
+export const ImmuneChains = ImmuneChain.options.map((o) => o.value);
+
+export const NotAlignedReason = z.union([
+  z.literal('NoHits'),
+  z.literal('FailedAfterAOverlap'),
+  z.literal('NoCDR3Parts'),
+  z.literal('NoVHits'),
+  z.literal('NoJHits'),
+  z.literal('VAndJOnDifferentTargets'),
+  z.literal('LowTotalScore'),
+  z.literal('NoBarcode'),
+  z.literal('SampleNotMatched'),
+]);
+export type NotAlignedReason = z.infer<typeof NotAlignedReason>;
+
+export const AlignmentChannel = z.union([
+  z.literal('Success'),
+  z.literal('NoHits'),
+  z.literal('NoCDR3Parts'),
+  z.literal('NoVHits'),
+  z.literal('NoJHits'),
+  z.literal('VAndJOnDifferentTargets'),
+  z.literal('LowTotalScore'),
+  z.literal('NoBarcode'),
+]);
+export type AlignmentChannel = z.infer<typeof AlignmentChannel>;
+
+/* Ordered list of channels */
+export const AlignmentChannels = [
+  'Success',
+  'NoHits',
+  'NoCDR3Parts',
+  'NoVHits',
+  'NoJHits',
+  'VAndJOnDifferentTargets',
+  'LowTotalScore',
+  'NoBarcode',
+] satisfies AlignmentChannel[];
+
+export const AlignmentChannelLabels = {
+  Success: 'Successfully aligned',
+  NoHits: 'No hits (not TCR/IG?)',
+  FailedAfterAOverlap: 'Failed after alignment-overlap',
+  NoCDR3Parts: 'No CDR3 parts',
+  NoVHits: 'No V hits',
+  NoJHits: 'No J hits',
+  VAndJOnDifferentTargets: 'No target with both V and J',
+  LowTotalScore: 'Low total score',
+  NoBarcode: 'Absent barcode',
+  SampleNotMatched: 'Sample not matched',
+} satisfies Record<NotAlignedReason | AlignmentChannel, string>;
+
+export const AlignmentChannelColors = {
+  Success: '#6BD67D',
+  NoHits: '#FEE27A',
+  FailedAfterAOverlap: 'red', // @TODO (was missing)
+  NoCDR3Parts: '#FEBF51',
+  NoVHits: '#FB9361',
+  NoJHits: '#E75B64',
+  VAndJOnDifferentTargets: '#B8397A',
+  LowTotalScore: '#7E2583',
+  NoBarcode: '#4B1979',
+  SampleNotMatched: '#2B125C',
+} satisfies Record<NotAlignedReason | AlignmentChannel, string>;
+
+export const AlignmentChainColors = {
+  '': {
+    total: '#A9A9A9',
+    hasStops: '#A9A9A9',
+    isOOF: '#A9A9A9',
+  },
+  'TRA': {
+    total: '#105BCC',
+    hasStops: '#2D93FA',
+    isOOF: '#99CCFF',
+  },
+  'TRAD': {
+    total: '#105BCC',
+    hasStops: '#2D93FA',
+    isOOF: '#99CCFF',
+  },
+  'TRB': {
+    total: '#198020',
+    hasStops: '#42B842',
+    isOOF: '#99E099',
+  },
+  'TRD': {
+    total: '#068A94',
+    hasStops: '#27C2C2',
+    isOOF: '#90E0E0',
+  },
+  'TRG': {
+    total: '#5F31CC',
+    hasStops: '#845CFF',
+    isOOF: '#C1ADFF',
+  },
+  'IGH': {
+    total: '#AD3757',
+    hasStops: '#F05670',
+    isOOF: '#FFADBA',
+  },
+  'IGL': {
+    total: '#C26A27',
+    hasStops: '#FF9429',
+    isOOF: '#FFCB8F',
+  },
+  'IGK': {
+    total: '#A324B2',
+    hasStops: '#E553E5',
+    isOOF: '#FAAAFA',
+  },
+} satisfies Record<ImmuneChain, Record<'total' | 'hasStops' | 'isOOF', string>>;
+
+export const CoveregeGeneFeature = z.union([
+  z.literal('CDR3'),
+  z.literal('FR3_TO_FR4'),
+  z.literal('CDR2_TO_FR4'),
+  z.literal('FR2_TO_FR4'),
+  z.literal('CDR1_TO_FR4'),
+  z.literal('VDJRegion'),
+]);
+export type CoveregeGeneFeature = z.infer<typeof CoveregeGeneFeature>;
+
+export const CoveregeGeneFeatureLabel = {
+  CDR3: 'CDR3',
+  CDR1_TO_FR4: 'CDR1 to FR4',
+  FR2_TO_FR4: 'FR2 to FR4',
+  CDR2_TO_FR4: 'CDR2 to FR4',
+  FR3_TO_FR4: 'FR3 to FR4',
+  VDJRegion: 'Full VDJRegion',
+} satisfies Record<CoveregeGeneFeature, string>;
+
+const ChainUsageEntry = z.object({
+  total: z.number().int(),
+  nonFunctional: z.number().int(),
+  isOOF: z.number().int(),
+  hasStops: z.number().int(),
+});
+
+const ChainUsage = z.object({
+  chimeras: z.number().int(),
+  total: z.number().int(),
+  chains: z.record(ImmuneChain, ChainUsageEntry),
+});
+
+export const AlignReport = z.object({
+  type: z.literal('alignerReport'),
+  totalReadsProcessed: z.number().int(),
+  aligned: z.number().int(),
+  notAligned: z.number().int(),
+  notAlignedReasons: z.record(NotAlignedReason, z.number().int()),
+  overlapped: z.number().int(),
+  overlappedAligned: z.number().int(),
+  overlappedNotAligned: z.number().int(),
+  alignmentAidedOverlaps: z.number().int(),
+  noCDR3PartsAlignments: z.number().int(),
+  partialAlignments: z.number().int(),
+  chimeras: z.number().int(),
+  vChimeras: z.number().int(),
+  jChimeras: z.number().int(),
+  pairedEndAlignmentConflicts: z.number().int(),
+  realignedWithForcedNonFloatingBound: z.number().int(),
+  realignedWithForcedNonFloatingRightBoundInLeftRead: z.number().int(),
+  realignedWithForcedNonFloatingLeftBoundInRightRead: z.number().int(),
+  chainUsage: ChainUsage,
+  coverage: z.record(CoveregeGeneFeature, z.number().int()),
+});
+export type AlignReport = z.infer<typeof AlignReport>;
+
+export function extractAlignmentChannels(report: AlignReport): [AlignmentChannel, number][] {
+  return AlignmentChannels.map((cId) => [
+    cId,
+    cId === 'Success' ? report.aligned : report.notAlignedReasons[cId] ?? 0,
+  ]);
+}
+
+const RoundedToInt = z.number().transform((n) => Math.round(n));
+
+export const AssembleReport = z.object({
+  type: z.literal('assemblerReport'),
+  readsDroppedNoTargetSequence: z.number().int(),
+  readsDroppedTooShortClonalSequence: z.number().int(),
+  readsDroppedLowQuality: z.number().int(),
+  coreReads: z.number().int(),
+  readsDroppedFailedMapping: z.number().int(),
+  lowQualityRescued: z.number().int(),
+  clonesClustered: z.number().int(),
+
+  clones: z.number().int(),
+  clonesDroppedAsLowQuality: z.number().int(),
+  clonesPreClustered: z.number().int(),
+  readsPreClustered: z.number().int(),
+
+  readsInClones: z.number().int(),
+  readsInClonesBeforeClustering: z.number().int(),
+  readsDroppedWithLowQualityClones: z.number().int(),
+
+  clonalChainUsage: ChainUsage,
+
+  clonesFilteredInFineFiltering: z.number().int(),
+  readsFilteredInFineFiltering: RoundedToInt,
+
+  clonesFilteredInPostFiltering: z.number().int(),
+  readsFilteredInPostFiltering: RoundedToInt,
+});
+export type AssembleReport = z.infer<typeof AssembleReport>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,17 +10,14 @@ catalogs:
       specifier: ^2.27.9
       version: 2.29.8
     '@milaboratories/helpers':
-      specifier: 1.14.0
-      version: 1.14.0
+      specifier: 1.14.1
+      version: 1.14.1
     '@milaboratories/ts-builder':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.3.1
+      version: 1.3.1
     '@milaboratories/ts-configs':
-      specifier: 1.2.2
-      version: 1.2.2
-    '@platforma-open/milaboratories.mixcr-clonotyping-2.model':
-      specifier: ^1.9.0
-      version: 1.23.0
+      specifier: 1.2.3
+      version: 1.2.3
     '@platforma-open/milaboratories.runenv-python-3':
       specifier: 1.4.16
       version: 1.4.16
@@ -34,29 +31,29 @@ catalogs:
       specifier: ^2.5.0-13-master
       version: 2.5.0-25-master
     '@platforma-sdk/block-tools':
-      specifier: 2.7.5
-      version: 2.7.5
+      specifier: 2.7.7
+      version: 2.7.7
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.61.1
-      version: 1.61.1
+      specifier: 1.63.12
+      version: 1.63.12
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.2
-      version: 2.5.2
+      specifier: 2.5.8
+      version: 2.5.8
     '@platforma-sdk/test':
-      specifier: 1.61.1
-      version: 1.61.1
+      specifier: 1.63.13
+      version: 1.63.13
     '@platforma-sdk/ui-vue':
-      specifier: 1.61.1
-      version: 1.61.1
+      specifier: 1.63.12
+      version: 1.63.12
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.11.0
-      version: 5.11.0
+      specifier: 5.13.1
+      version: 5.13.1
     '@types/wicg-file-system-access':
       specifier: ^2023.10.6
       version: 2023.10.7
@@ -87,6 +84,9 @@ catalogs:
     vue:
       specifier: ^3.5.12
       version: 3.5.27
+    zod:
+      specifier: ~3.23.8
+      version: 3.23.8
 
 importers:
 
@@ -97,7 +97,7 @@ importers:
         version: 2.29.8(@types/node@25.2.0)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.7.7
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -121,23 +121,26 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.7.7
 
   model:
     dependencies:
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.63.12
+      zod:
+        specifier: 'catalog:'
+        version: 3.23.8
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.3.0(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.3.1(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.2.2
+        version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.7.7
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.2(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.54.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -168,16 +171,16 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.3.0(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.3.1(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.2.2
+        version: 1.2.3
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.2(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.54.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.61.1(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 1.63.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.2.0)(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -192,19 +195,16 @@ importers:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.0
-      '@platforma-open/milaboratories.mixcr-clonotyping-2.model':
-        specifier: 'catalog:'
-        version: 1.23.0
+        version: 1.14.1
       '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.63.12
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.61.1(typescript@5.6.3)
+        version: 1.63.12(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@zip.js/zip.js':
         specifier: 'catalog:'
         version: 2.8.16
@@ -220,10 +220,10 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.3.0(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.3.1(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.2.2
+        version: 1.2.3
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.2(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.54.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -256,11 +256,11 @@ importers:
         version: 2.5.0-25-master
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.11.0
+        version: 5.13.1
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.2
+        version: 2.5.8
 
 packages:
 
@@ -495,8 +495,8 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0-rc.2':
-    resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
+  '@babel/generator@8.0.0-rc.3':
+    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-compilation-targets@7.28.6':
@@ -529,8 +529,8 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.2':
-    resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
+  '@babel/helper-validator-identifier@8.0.0-rc.3':
+    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-option@7.27.1':
@@ -546,8 +546,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@8.0.0-rc.2':
-    resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
+  '@babel/parser@8.0.0-rc.3':
+    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -567,8 +567,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@8.0.0-rc.2':
-    resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
+  '@babel/types@8.0.0-rc.3':
+    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bufbuild/protobuf@2.11.0':
@@ -642,14 +642,14 @@ packages:
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -957,8 +957,8 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@milaboratories/computable@2.9.0':
-    resolution: {integrity: sha512-W1/Y24zjSlONetigr9i7lYDbSIvCeU6w3iuqyRo5ZREq8WGrHRNwl0a1bpwQGmDnn0I0SZa1tLj3d72aOjNsVg==}
+  '@milaboratories/computable@2.9.2':
+    resolution: {integrity: sha512-MXDXRqfJLV1dFK9PgMpdgRyixVAElnqAF0/CSGiyQ6e3+BhPtdmH+xpVz9HYR5cXe54VFQSUQlDTpNch4m4ERg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/helpers@1.13.5':
@@ -973,91 +973,76 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.2.0':
-    resolution: {integrity: sha512-pWmySK1Zj2ivwSuPwaIQoHUx2GNzfgrYQf43RoHveKHpbYqTXmb1Ow8BlOmtDL8e/pD0dVg32idYRPtpw+615A==}
+  '@milaboratories/pf-driver@1.3.5':
+    resolution: {integrity: sha512-wYPERfpDqEP9Y/cGaHBpvodE6qCgn8Fpc8GZP+u5f8Cu2rEI3wYCYY9Cvh2APSXgxeekglHdRPxusucibD/rqA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-spec-driver@1.1.0':
-    resolution: {integrity: sha512-9+h+zxVorK5tp74e9u0GyNX1BKCSUPgltUXrDa8SyHhqVtTmqsBaj9823bD8gH4CBe2GNPba+NMprGQ7SzaLDw==}
+  '@milaboratories/pf-spec-driver@1.2.5':
+    resolution: {integrity: sha512-2f3MZ1WsUNowePpTbpf0Kg5k4GegmPIDn7YLcHQoel8vItatO4gVUeq8URib9X5Q79qafpxwMUT3NBkXge66Lw==}
 
-  '@milaboratories/pframes-rs-node@1.1.15':
-    resolution: {integrity: sha512-Wuv5gJGzJZZ6+Po4bJ6SOSbzbdBhO31LW/M2SeKfl0l56ZjdIajawXHHwV8hn7gjKueuD+KyoYdI5TBjwcMHmA==}
+  '@milaboratories/pframes-rs-node@1.1.18':
+    resolution: {integrity: sha512-zK0pq5MzbRw0ihDpUJ68+yPb/xd7fbyf7HWwazMa0bB4hFZKn8Pn1LAAfJ5GV7OdwZHG6vckB46mK5m7nOlOhg==}
 
-  '@milaboratories/pframes-rs-serv@1.1.15':
-    resolution: {integrity: sha512-lu3fNpm8HetpCm+w/T+zmfZuL1B//eVw1Holc/HwAE5gKqDlN43mdElEDRdiD7HZv6YmEMTz8FRqhZVzqS1uLw==}
+  '@milaboratories/pframes-rs-serv@1.1.18':
+    resolution: {integrity: sha512-1kqvvfkoC0gFl17IUdtBlRoQJzYYYJl6iMiOnFHcvHwbRUskJRw77c+r54kZW8BQ/VFY8Pgry6yY+mZk2JVrGQ==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasm@1.1.15':
-    resolution: {integrity: sha512-jbwC1UM/beaCb4VpJtHLntFqshw37LD9q+QajMcT5iAC36PKFa9Xx+WCiAlSG70BLBS1svSyWCGcbj60Nyudgg==}
+  '@milaboratories/pframes-rs-wasm@1.1.18':
+    resolution: {integrity: sha512-K/Th/EGE5CBtCa1+w6ikYai/LHMi71eE5y+tObSxsHrZeOUP+J704xPaDbIV4CW2XOzS3VStY9AZCrOX4GrBWA==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pl-model-common': 1.28.0
       '@milaboratories/pl-model-middle-layer': 1.15.0
 
-  '@milaboratories/pl-client@2.18.2':
-    resolution: {integrity: sha512-b7Ku6wp1m7m6iQjstDu08YUUUAM8dNMbLlCioPkIUuNT3iH4CmueCRrxsRi4Dk8pWY3K2+LGz5YubkJAGLPmQg==}
+  '@milaboratories/pl-client@3.1.1':
+    resolution: {integrity: sha512-2h9PiaDUneZT6ieNnlet8A8HrwntUxJwxDmivXvXUEbiEStvsLnnrytkyYWMRS2PdwMrqbujZACyKbcdkOBMLQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.7.15':
-    resolution: {integrity: sha512-XYkyYdoPFGtxIVogCmQ6tGupUBoi1gtfLnTdd/i8Qqfnk/P673hr8TTH+CBAglqNbrg+jubw4oYO4cLpGIEzfA==}
+  '@milaboratories/pl-config@1.7.17':
+    resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
 
-  '@milaboratories/pl-deployments@2.16.2':
-    resolution: {integrity: sha512-X1ACxPk/N6ypXPMCFotr2LlDqWKrEwikIuM705USW6yvlEvBgGGPMOxJZ56gZWjnb7tNwWJ5wkMtFExBPtQCGQ==}
+  '@milaboratories/pl-deployments@2.16.6':
+    resolution: {integrity: sha512-gMXPQr6aQC/GRGLLwDiLbnxiHpF3AXkcotwUjbhH5VKwwGO2BrWH3j6oo8H6898l9CzXZBclTjc9YNOX1RVA/A==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.12.3':
-    resolution: {integrity: sha512-7kpZn/cnHCeKmTA4kUAK7KpSZVrhZWXn+Hj/HjDfZfERdzx3BSTiyD5TWVCrySE6bzNd8g07KIzeGBU1SHOOZw==}
+  '@milaboratories/pl-drivers@1.12.10':
+    resolution: {integrity: sha512-Qkf42j3u5vMrC7WdGBNxabocNAcPCxMrHa78nwh7q05s+JOW5ZtoGGutqQ9Qfxh+0R6BkQc3QA1pEP+iNcoEQw==}
     engines: {node: '>=22'}
-
-  '@milaboratories/pl-error-like@1.12.5':
-    resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.2.2':
-    resolution: {integrity: sha512-NHdXeHYXEabfH+fcTVlr0OtrxyoyRxOcVvvKr1VIqM4rNV371ew10ZmgbP1oekmZDJ/T8zxkj9YpEV2KlsOSsA==}
+  '@milaboratories/pl-errors@1.2.8':
+    resolution: {integrity: sha512-Q2aeZKOdVjGKGn7MDRWTpHyPyE/DzeKTlJIz3WGocwkgnpT1DdPB8pz4nEvdUDg33N2GHJqi/YOyemhvMAzFhg==}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.53.1':
-    resolution: {integrity: sha512-mhw6D/MZMZmtTHdg7urTOo1MPsF4OQuxNHBmb3tBsiBT8qUvR/xtkC421TWb9kvjlQxRju7pURFKzgjStPIrlw==}
+  '@milaboratories/pl-middle-layer@1.55.7':
+    resolution: {integrity: sha512-PlV3JlUCG6s7+/c+Oye9mA/2g8gMkARnuv1h1zyuvNz8VBDVtJ6w4z/KIYsHIICr9qlUgMH8PCbZJ4laYA+VEA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.2.2':
-    resolution: {integrity: sha512-mgErl5jffNisR9vgMpyZlcPwrQaf0+2PkxL2ByKP6F3jVRkhXwXCf5ACTGbQnON69eg/rvGXkR7Zl89rgc6JRg==}
-
-  '@milaboratories/pl-model-common@1.23.0':
-    resolution: {integrity: sha512-1uHb2pS+hWJyBKvfOlMYmjbFuWn+tNOULWj84mWASdqSjdYyHfVYbLq5esawM+dnZ2GBQIzJRbXrZYIMqH4Peg==}
+  '@milaboratories/pl-model-backend@1.2.8':
+    resolution: {integrity: sha512-bIzTeSowEuSHENqb9x5Ypf0SIw3ed+B6JfvQU5Udf12yQFDmNsyJ9sVylSnLbNzUkTVtuj7e9FomySOH8XZkQg==}
 
   '@milaboratories/pl-model-common@1.28.0':
     resolution: {integrity: sha512-VGfXSzep5LR8vnj7El0ksDiZEmELhT8jB7EeXv3VIOmYZj4cPYbkNsb+54wrBloMzyIc1iG1H13ucR44qbv/bw==}
 
-  '@milaboratories/pl-model-common@1.29.0':
-    resolution: {integrity: sha512-on2ysnEIchh+XsTL46lphRwjyXm4aX0bGS0aEDlgAh67Z60BfrtvS5Q+MGgbS+ZQSFYZiWrun32KmXMxqjI/RA==}
-
-  '@milaboratories/pl-model-common@1.31.1':
-    resolution: {integrity: sha512-MLQvhXXFOykABZr8aVgzt5x0htT7ye4cvvnVy0TgOITXpct+lEmWvaVj29zirK/0VFw7wnTXDGnLwusr77NZFA==}
+  '@milaboratories/pl-model-common@1.31.2':
+    resolution: {integrity: sha512-dnK0zXzylN7MAO1Nyx8EJargaqa94iDDEDwZW7d1/lRl1p50cR9zGP8pUnIy1I8UcI4lzH34f81RRQy6AbTuTw==}
 
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
 
-  '@milaboratories/pl-model-middle-layer@1.16.0':
-    resolution: {integrity: sha512-fua7s/VWz0J2vpBN5bd4BzahyVZQHHZoTCPL7hXzwanPwPfeeCpnm1Hd/3yYj6cYKilaG9S82aOwAPXIq9WeOg==}
+  '@milaboratories/pl-model-middle-layer@1.16.4':
+    resolution: {integrity: sha512-uFTZHEjRmfRvY97tRbBuTvNzQnTYIj58S8HBzyMsFkzxbUI8vTBPtvEqbTU2IbQ31IEGvv8T0BBl9b7/vdud0A==}
 
-  '@milaboratories/pl-model-middle-layer@1.16.3':
-    resolution: {integrity: sha512-XLZEC3POgUMNNjXr3Pudh7gx2CXZygeskxuQCyPfj4c8Fi35+kAfH9VBpNZD1koiT2n+x5QZyS3RpzcAddQTnQ==}
-
-  '@milaboratories/pl-tree@1.9.3':
-    resolution: {integrity: sha512-cPYI8oY+pLcvNRpnurMcg8xbSQrSv47Rhz0LfxPA71wLK41ICK9g5Ch8fkYP0E9jsASIwWDDSMT5PlckRpoY/w==}
+  '@milaboratories/pl-tree@1.9.9':
+    resolution: {integrity: sha512-WHeWAR8xAfobdpXBFJY5rBV6lPkpMrfWLiNAROozWp9S16EHFlauHS//ykcxyqwr438HLjkGurDCygbS5COvmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.1.9':
-    resolution: {integrity: sha512-fH0gix6ObRI9/TgPk1S40EkdFLskSdh6AloNBhkedH7WyTwOmM7zmtjmp+n7TiRHzRfufqzwLOZ9TFb7qAXQRA==}
-
-  '@milaboratories/ptabler-expression-js@1.2.2':
-    resolution: {integrity: sha512-1E8QqsKdoMOgF0GpfoRe/MzntBl7Y7hdyqQmmY54lKvHXclkx61aEWwIGrdL14D/eYu/kvlpQQ0z80rUsLjabg==}
+  '@milaboratories/ptabler-expression-js@1.2.6':
+    resolution: {integrity: sha512-bjiDfy8Iy7iFV9i/PlFgIWPu4WoidzWt10PYiDQXcQsJPuP2CsXgwlQGW7RMaJeJYCvyFBVv0HtsRWk8IPvHtw==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1070,36 +1055,36 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.3.0':
-    resolution: {integrity: sha512-r3iAYwO8dpg/6NC9MQgrIFs8mPKLeB6wArXH8d6muazXwHEYxwEc4Xc5PlUWHcq+uFGgnbTU99wZndycO0feXA==}
+  '@milaboratories/ts-builder@1.3.1':
+    resolution: {integrity: sha512-p9OkdDa7u1V+FemFUZozfiNutu1lRM7EeTgOOiIPoRUPGLu0UBoXFrVezfojmy9JLQSA5kETZPGJQp8X/Gc4Yg==}
     hasBin: true
 
-  '@milaboratories/ts-configs@1.2.2':
-    resolution: {integrity: sha512-tZEsBTgtyyn5HAEAF/PkOABVHI8bCwP5RV425a+IP+9M2V/iac2Rpqs1ZfhmdutQTJbmxLF5GhjHD6HOXXqM0A==}
-
-  '@milaboratories/ts-helpers-oclif@1.1.38':
-    resolution: {integrity: sha512-acc/gmGKtpg5fUhNoPXoYh+rcKzl7KoXOa9JWyNpvXcKirx1Q6+Cc14OdlbbxxUOS9P+5cLKW1youkLuT/jemQ==}
+  '@milaboratories/ts-configs@1.2.3':
+    resolution: {integrity: sha512-NALtuzTbSzAz2Uk7X1sWq3rBo4XAV/vAQ1Mf7IfiNiv1euZ+0+TF0NDJMNiEcU6BT/Q55dATSKhIY2r680ljXw==}
 
   '@milaboratories/ts-helpers-oclif@1.1.40':
     resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
-
-  '@milaboratories/ts-helpers@1.7.3':
-    resolution: {integrity: sha512-65/URvZfb5moAyIaRKoExjam5ZcXHg9EyepFU7dnUBpPaW0q5+HTS6ThQDIiGJk63qwXe9qyyDgIbSqyhFWulw==}
-    engines: {node: '>=22.19.0'}
 
   '@milaboratories/ts-helpers@1.8.1':
     resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.11.3':
-    resolution: {integrity: sha512-BL1ZUPmExcctNjSgD+/ag1jQQA60naWCRS+WOvlk6FMqfxsy6S7LQhEV7/1ToR7PBcaVEcoh+k5mhCOnTVjr0g==}
+  '@milaboratories/uikit@2.11.8':
+    resolution: {integrity: sha512-+GzIyZ2MSWlaLFWLpW+iMsnUL/ifiMIyRSmPKzTfL2x4Yq60VpWDkd6a/Cm0SRyM+pCMX8zhoRbfl2+5jaRXVQ==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1120,15 +1105,8 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@oxc-project/runtime@0.114.0':
-    resolution: {integrity: sha512-mVGQvr/uFJGQ3hsvgQ1sJfh79t5owyZZZtw+VaH+WhtvsmtgjT6imznB9sz2Q67Q0/4obM9mOOtQscU4aJteSg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.114.0':
-    resolution: {integrity: sha512-//nBfbzHQHvJs8oFIjv6coZ6uxQ4alLfiPe6D5vit6c4pmxATHHlVwgB1k+Hv4yoAMyncdxgRBF5K4BYWUCzvA==}
-
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     resolution: {integrity: sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==}
@@ -1322,9 +1300,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@platforma-open/milaboratories.mixcr-clonotyping-2.model@1.23.0':
-    resolution: {integrity: sha512-+wada8yU5nOD0Vf9vNGDrp/KVcNllW+GFKA6BCWHeatnDKmGDFx8/Una+eD6j4L14Polcc0KzTM+ehZxdeVa3Q==}
-
   '@platforma-open/milaboratories.runenv-python-3.10.11@1.1.16':
     resolution: {integrity: sha512-VAl4vIW6/vRRrhb5civ5V8Tj5FVZJPWNmEUA7AVq8fiFpp1xbhla5GHDJ10aN/kxUz3ZD695a+EW/HiUK9nV9A==}
 
@@ -1343,11 +1318,8 @@ packages:
   '@platforma-open/milaboratories.software-mixcr@4.7.0-343-develop':
     resolution: {integrity: sha512-cEEq2fc/SgejoTXrB61S7Tw/1A57p8z/kPzOE/ujoS182yHRTMSCt7X08QnpyHud86fFBu9zv/e1/ZHVaq6wMA==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.2':
-    resolution: {integrity: sha512-xQ5eD6WNLL490bQY2kEH/Dz+0SE5uyLexwOQzoUpKhBqdYb4eIKGA2NnZ9SDOgfDoiNFzTeYGQhuI+R3W6P0Og==}
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.2':
-    resolution: {integrity: sha512-iqGFCOxbRVPOAiEH+dTtD1Y0nMjh07X/GHFJpB7LZ4Gb84DdIdcxs4jPWhT+uUFQ7rGz473K8m4FigY+34vkpw==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.14.6':
+    resolution: {integrity: sha512-X9e81kETOcYQIx8n96cs7o1LvM3A1U8jeaaJJXoWuakMWP7+NVqK7rIdfcWPL5wIpjAKVpBUbuuHNctrzy23Tw==}
 
   '@platforma-open/milaboratories.software-ptabler@1.15.0':
     resolution: {integrity: sha512-7hbuOsIU3WsmAsBwWoVfP1UyZPBQj/Ec8KGoUBoaAq5VNjVQ7oQR3Nx4co+dIJJ9+cEB3c633Xx1DNxebb5uNQ==}
@@ -1361,27 +1333,23 @@ packages:
   '@platforma-open/milaboratories.software-repseqio@2.5.0-25-master':
     resolution: {integrity: sha512-Z/nq0nT3bI0GKweJcQaVZzYe5xBGzxi3ToByrMyN+WhfknqSetULociQEvQuNJPKv/B0hi640Sm21pSAaxSVJA==}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.9':
-    resolution: {integrity: sha512-pCg5NZREkrzBqx7jXv14MQMGWh2nfB9JJMn4MoF0lYJjLGkXpyFyYSVErW8IIvbNHcFLE5tU1pG7zilP/wSPvg==}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
+    resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.5':
-    resolution: {integrity: sha512-CqlJEDZGmSdamYthPo9jQB6teYVGOs16I8P5eQE+AUVYCGXr0kxrk316CTsegPsg1gxhdw1I0FwljNOloVrIgA==}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7':
+    resolution: {integrity: sha512-CqXbfFld2l6Y/8rtcZXRPsa5kqNnaS3QWUxrcfMYwNxultbhLzjZGdqSR7ejV9xRWilXpeg6DdZJIKF3+KDH8g==}
 
-  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.3':
-    resolution: {integrity: sha512-hrY/UoOUtqyRtEV20h12GvHH5WlixcbyK5SVHJjj1q3ewvM2svo25bADK0cKsopzwFBkzZU984fpy9evpBeBzg==}
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5':
+    resolution: {integrity: sha512-ZdVg77pZ0Hgvxdk+mYahEyPbcTzDyz6Y7qlm6A0rJw8WCYmDVkfLqctQj0QkTLHM76oSWOHJIgD07ZxORjjgwA==}
 
-  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.3':
-    resolution: {integrity: sha512-1PCVZaOiEWkv9g2XZDdR6UPGS28mV/PPMVeIxTr5FOR9/ibfX29rohOClxRZIFqKgGN+/vH/GxKrk3aU2jTRUg==}
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5':
+    resolution: {integrity: sha512-x6WOZ8S3uLXzmwliCF500hw7VQ4A9U3VBbESjJlPia26aU91FqB3ylKyH2fEyTiVw2wADlTYuui1tHX47iS5Lw==}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.2':
-    resolution: {integrity: sha512-/ViK6kJDjCL/0jBFuEqLwSrpLK4afnR4XiHFOvIlaiYgWHeRU4Gw3aCSMRo6lhG3r6YeeWBqZ9FCkGKKy3TPvg==}
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
-  '@platforma-sdk/block-tools@2.7.2':
-    resolution: {integrity: sha512-9FUIS1PutS97fPsuay3l13bXBdpRBhtIz9ZcKLdaVbniUzrl2u4kY8ne80zRbTXKCEzZ5EaePFsuVoywAco0wQ==}
-    hasBin: true
-
-  '@platforma-sdk/block-tools@2.7.5':
-    resolution: {integrity: sha512-PB8cMAzcXfWO9lV/KVE1vcoRoMDESnZt4IlObSL3+vpwSZWB4oLlv3TbrYpXz0dPni/Bmi9bMXwDOXhksuob9w==}
+  '@platforma-sdk/block-tools@2.7.7':
+    resolution: {integrity: sha512-pcepxZC9XpSRdKIzb5AarCwvzSqPcr38QJZFo34iQiZF4/fVyFtPLOxT/Lux5eYWGiE82dw0xok4xfO4s7AELA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1400,29 +1368,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.51.6':
-    resolution: {integrity: sha512-UgFbC7gPtH4qMwZ0opbM7Tcs8mCMlbjHzJsqs1wD2gxc22l4QvAQOHiIZh2i8dmXny8ny+TwQ/6L8nPaRHqk5g==}
-
-  '@platforma-sdk/model@1.61.1':
-    resolution: {integrity: sha512-OOXR/9MiUlWcCzKtG2qUqYV1Z55R6h4oOWD/RugU6pu55wbLmV0srQA4r4CNFKr6773bPc+/hvBqFXD7BgciZw==}
+  '@platforma-sdk/model@1.63.12':
+    resolution: {integrity: sha512-kBwoq9VO8rqjUb5aZNofF04LGJjc8mhLXuaJzRK954MQVvqMIXv6PrvEakKCfMxfZevyP6x2Gpf6i2A6a9OrOA==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.2':
-    resolution: {integrity: sha512-gFLhyT5ak25BPd5akjlQ3yz6CB1Hcou3pn67Q6nhILakJrdcU22I7L9F0T3QBuf0tbpQPk7N3mQtNrE9LrW2XA==}
+  '@platforma-sdk/tengo-builder@2.5.8':
+    resolution: {integrity: sha512-VztI3+WC8qc5tB2L8rX/RvbzNV/xMBJ5/yGCmKQ5BaIHMbtk/bJdPlBuasCcOkUo0PNNr0ivZt6vZGcUTxfvrA==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.61.1':
-    resolution: {integrity: sha512-mR/ZOwj7FzDRMd2DOpjkGMsJrh9BeKMMh6EuyBiwNKsB6yKCOoxwbvENmRwIpuswSFLT+DzxpZCFvVJxAowrZw==}
+  '@platforma-sdk/test@1.63.13':
+    resolution: {integrity: sha512-oilhQvK2pRlgt8jmjhevnSiZNKcbbWoEpLT3SFXzioLqi20o5mzKkufyxpVXeIonm9RoXOLOhfzNxVQt8ancOw==}
 
-  '@platforma-sdk/ui-vue@1.61.1':
-    resolution: {integrity: sha512-/W06aUdhukMgBec23XXIgTf1gxjOsP+aYNcCIvVt0fYu5F9cLFYCMGVZxyfyn8koePYBBJQUrxLvnvTFiEQXHw==}
+  '@platforma-sdk/ui-vue@1.63.12':
+    resolution: {integrity: sha512-gDEAKQHNMitjc5LqX24CEfl914vwPBLoQsyiynGvWuFKbs/oxS5lLqHw4hHlsunQ3CTC1swhFNul43scfdIa8Q==}
 
-  '@platforma-sdk/workflow-tengo@5.11.0':
-    resolution: {integrity: sha512-+jH4xSqWABB6DCKFvfWrUVYuoBwWrfNObGi9a1zSWvAQZFw++V5nlJLG0nfdoTNnCXiXBl+9nseMenjDBMM6kg==}
+  '@platforma-sdk/workflow-tengo@5.13.1':
+    resolution: {integrity: sha512-8XcfEuc3/GqVV2CTgwNCKVgwGB43kvAg/znlug4Gcc24uva7eudlCmcURI/1H8CQ35bpQZKhL+I5oJnm4b6xCA==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -1473,180 +1438,100 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.5':
-    resolution: {integrity: sha512-zCEmUrt1bggwgBgeKLxNj217J1OrChrp3jJt24VK9jAharSTeVaHODNL+LpcQVhRz+FktYWfT9cjo5oZ99ZLpg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.5':
-    resolution: {integrity: sha512-ZP9xb9lPAex36pvkNWCjSEJW/Gfdm9I3ssiqOFLmpZ/vosPXgpoGxCmh+dX1Qs+/bWQE6toNFXWWL8vYoKoK9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
-    resolution: {integrity: sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.5':
-    resolution: {integrity: sha512-7IdrPunf6dp9mywMgTOKMMGDnMHQ6+h5gRl6LW8rhD8WK2kXX0IwzcM5Zc0B5J7xQs8QWOlKjv8BJsU/1CD3pg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
-    resolution: {integrity: sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.5':
-    resolution: {integrity: sha512-o/JCk+dL0IN68EBhZ4DqfsfvxPfMeoM6cJtxORC1YYoxGHZyth2Kb2maXDb4oddw2wu8iIbnYXYPEzBtAF5CAg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
-    resolution: {integrity: sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.5':
-    resolution: {integrity: sha512-IIBwTtA6VwxQLcEgq2mfrUgam7VvPZjhd/jxmeS1npM+edWsrrpRLHUdze+sk4rhb8/xpP3flemgcZXXUW6ukw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.5':
-    resolution: {integrity: sha512-KSol1De1spMZL+Xg7K5IBWXIvRWv7+pveaxFWXpezezAG7CS6ojzRjtCGCiLxQricutTAi/LkNWKMsd2wNhMKQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
-    resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.5':
-    resolution: {integrity: sha512-WFljyDkxtXRlWxMjxeegf7xMYXxUr8u7JdXlOEWKYgDqEgxUnSEsVDxBiNWQ1D5kQKwf8Wo4sVKEYPRhCdsjwA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.5':
-    resolution: {integrity: sha512-CUlplTujmbDWp2gamvrqVKi2Or8lmngXT1WxsizJfts7JrvfGhZObciaY/+CbdbS9qNnskvwMZNEhTPrn7b+WA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
-    resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.5':
-    resolution: {integrity: sha512-wdf7g9NbVZCeAo2iGhsjJb7I8ZFfs6X8bumfrWg82VK+8P6AlLXwk48a1ASiJQDTS7Svq2xVzZg3sGO2aXpHRA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.5':
-    resolution: {integrity: sha512-0CWY7ubu12nhzz+tkpHjoG3IRSTlWYe0wrfJRf4qqjqQSGtAYgoL9kwzdvlhaFdZ5ffVeyYw9qLsChcjUMEloQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
-    resolution: {integrity: sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.5':
-    resolution: {integrity: sha512-LztXnGzv6t2u830mnZrFLRVqT/DPJ9DL4ZTz/y93rqUVkeHjMMYIYaFj+BUthiYxbVH9dH0SZYufETspKY/NhA==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
-    resolution: {integrity: sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.5':
-    resolution: {integrity: sha512-jUct1XVeGtyjqJXEAfvdFa8xoigYZ2rge7nYEm70ppQxpfH9ze2fbIrpHmP2tNM2vL/F6Dd0CpXhpjPbC6bSxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
-    resolution: {integrity: sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.5':
-    resolution: {integrity: sha512-VQ8F9ld5gw29epjnVGdrx8ugiLTe8BMqmhDYy7nGbdeDo4HAt4bgdZvLbViEhg7DZyHLpiEUlO5/jPSUrIuxRQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.11':
-    resolution: {integrity: sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==}
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
-
-  '@rolldown/pluginutils@1.0.0-rc.5':
-    resolution: {integrity: sha512-RxlLX/DPoarZ9PtxVrQgZhPoor987YtKQqCo5zkjX+0S0yLJ7Vv515Wk6+xtTL67VONKJKxETWZwuZjss2idYw==}
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -2202,16 +2087,16 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-istanbul@4.0.18':
-    resolution: {integrity: sha512-0OhjP30owEDihYTZGWuq20rNtV1RjjJs1Mv4MaZIKcFBmiLUXX7HJLX4fU7wE+Mrc3lQxI2HKq6WrSXi5FGuCQ==}
+  '@vitest/coverage-istanbul@4.1.4':
+    resolution: {integrity: sha512-Pyi4F8RnqU6hBGiIDhS/e8gVD4FRcUvZJ2AbFiIlmIxHlEIsKyCxGOqufCECobty/dXELcN8oIH4Gms3hVOCYA==}
     peerDependencies:
-      vitest: 4.0.18
+      vitest: 4.1.4
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -2224,11 +2109,11 @@ packages:
       vite:
         optional: true
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2238,47 +2123,38 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
-
-  '@volar/language-core@2.4.15':
-    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@2.4.15':
-    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
-
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
-
-  '@volar/typescript@2.4.15':
-    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
@@ -2306,13 +2182,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@2.2.12':
-    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@vue/language-core@3.2.6':
+    resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
 
   '@vue/reactivity@3.5.27':
     resolution: {integrity: sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==}
@@ -2473,8 +2344,8 @@ packages:
   alien-signals@0.4.14:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
-  alien-signals@1.0.13:
-    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+  alien-signals@3.1.2:
+    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2995,6 +2866,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3475,10 +3349,6 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-instrument@6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
-    engines: {node: '>=10'}
-
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
@@ -3697,8 +3567,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.1:
-    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
   make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
@@ -3952,6 +3822,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -3992,6 +3866,10 @@ packages:
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -4100,14 +3978,14 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown-plugin-dts@0.22.5:
-    resolution: {integrity: sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw==}
+  rolldown-plugin-dts@0.23.2:
+    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
-      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
-      rolldown: ^1.0.0-rc.3
-      typescript: ^5.0.0 || ^6.0.0-beta
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0-rc.12
+      typescript: ^5.0.0 || ^6.0.0
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -4119,13 +3997,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.11:
-    resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.0.0-rc.5:
-    resolution: {integrity: sha512-0AdalTs6hNTioaCYIkAa7+xsmHBfU5hCNclZnM/lp7lGGDuUOb6N4BVNtwiomybbencDjq/waKjTImqiGCs5sw==}
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4264,6 +4137,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
@@ -4387,8 +4263,8 @@ packages:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -4588,10 +4464,10 @@ packages:
   vite-plugin-dynamic-import@1.6.0:
     resolution: {integrity: sha512-TM0sz70wfzTIo9YCxVFwS8OA9lNREsh+0vMHGSkWDTZ7bgd1Yjs5RV8EgB634l/91IsXJReg0xtmuQqP0mf+rg==}
 
-  vite-plugin-externalize-deps@0.9.0:
-    resolution: {integrity: sha512-wg3qb5gCy2d1KpPKyD9wkXMcYJ84yjgziHrStq9/8R7chhUC73mhQz+tVtvhFiICQHsBn1pnkY4IBbPqF9JHNw==}
+  vite-plugin-externalize-deps@0.10.0:
+    resolution: {integrity: sha512-eQrtpT/Do7AvDn76l1yL6ZHyXJ+UWH2LaHVqhAes9go54qaAnPZuMbgxcroQ/7WY3ZyetZzYW2quQnDF0DV5qg==}
     peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite-plugin-lib-inject-css@2.2.2:
     resolution: {integrity: sha512-NF30p0GwtfSAmVlxo2NgPXM2rEdtgV7LFi4lkzajKD7P3Ru/ZAFmI533M0Z5qyMZpvNMxVGkewzpjD0HOWtbDQ==}
@@ -4638,14 +4514,14 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.0-beta.15:
-    resolution: {integrity: sha512-RHX7IvsJlEfjyA1rS7MY0UsmF91etdLAamslHR5lfuO3W/BXRdXm2tRE64ztpSPZbKqB4wAAZ0AwtF6QzfKZLA==}
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.0.0-alpha.31
-      esbuild: ^0.27.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4709,20 +4585,23 @@ packages:
       jsdom:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4735,6 +4614,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4755,8 +4638,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  vue-tsc@2.2.12:
-    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+  vue-tsc@3.2.6:
+    resolution: {integrity: sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -4871,6 +4754,9 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
@@ -5429,10 +5315,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@8.0.0-rc.2':
+  '@babel/generator@8.0.0-rc.3':
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -5470,7 +5356,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.2': {}
+  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -5483,9 +5369,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/parser@8.0.0-rc.2':
+  '@babel/parser@8.0.0-rc.3':
     dependencies:
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.3
 
   '@babel/runtime@7.28.6': {}
 
@@ -5512,10 +5398,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@8.0.0-rc.2':
+  '@babel/types@8.0.0-rc.3':
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
 
   '@bufbuild/protobuf@2.11.0': {}
 
@@ -5681,18 +5567,18 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.9.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5976,10 +5862,10 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@milaboratories/computable@2.9.0':
+  '@milaboratories/computable@2.9.2':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.9
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/ts-helpers': 1.8.1
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
@@ -5989,13 +5875,14 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/pf-driver@1.2.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.3.5(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/pframes-rs-node': 1.1.15
-      '@milaboratories/pframes-rs-wasm': 1.1.15(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.29.0)(@milaboratories/pl-model-middle-layer@1.16.0)
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pframes-rs-node': 1.1.18
+      '@milaboratories/pframes-rs-wasm': 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.2)(@milaboratories/pl-model-middle-layer@1.16.4)
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
+      '@milaboratories/ts-helpers': 1.8.1
       es-toolkit: 1.44.0
       lru-cache: 11.2.5
     transitivePeerDependencies:
@@ -6003,26 +5890,28 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-spec-driver@1.1.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.2.5(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/pframes-rs-wasm': 1.1.15(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.29.0)(@milaboratories/pl-model-middle-layer@1.16.0)
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pframes-rs-wasm': 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.2)(@milaboratories/pl-model-middle-layer@1.16.4)
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
+      '@noble/hashes': 2.2.0
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.15':
+  '@milaboratories/pframes-rs-node@1.1.18':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pframes-rs-serv': 1.1.15
+      '@milaboratories/pframes-rs-serv': 1.1.18
       '@milaboratories/pl-model-common': 1.28.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.15':
+  '@milaboratories/pframes-rs-serv@1.1.18':
     dependencies:
       '@milaboratories/helpers': 1.13.5
       '@milaboratories/pl-model-common': 1.28.0
@@ -6030,18 +5919,18 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.15(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.29.0)(@milaboratories/pl-model-middle-layer@1.16.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.2)(@milaboratories/pl-model-middle-layer@1.16.4)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
 
-  '@milaboratories/pl-client@2.18.2':
+  '@milaboratories/pl-client@3.1.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/ts-helpers': 1.8.1
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6054,35 +5943,35 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-config@1.7.15':
+  '@milaboratories/pl-config@1.7.17':
     dependencies:
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/ts-helpers': 1.8.1
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@2.16.2':
+  '@milaboratories/pl-deployments@2.16.6':
     dependencies:
-      '@milaboratories/pl-config': 1.7.15
+      '@milaboratories/pl-config': 1.7.17
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/ts-helpers': 1.8.1
       decompress: 4.2.1
       ssh2: 1.17.0
       tar: 7.5.7
       undici: 7.16.0
       upath: 2.0.1
       yaml: 2.8.2
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.12.3':
+  '@milaboratories/pl-drivers@1.12.10':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.0
-      '@milaboratories/helpers': 1.14.0
-      '@milaboratories/pl-client': 2.18.2
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-tree': 1.9.3
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/computable': 2.9.2
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-tree': 1.9.9
+      '@milaboratories/ts-helpers': 1.8.1
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -6092,55 +5981,50 @@ snapshots:
       openapi-fetch: 0.15.0
       tar-fs: 3.1.1
       undici: 7.16.0
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-error-like@1.12.5':
-    dependencies:
-      canonicalize: 2.1.0
-      json-stringify-safe: 5.0.1
-      zod: 3.23.8
-
   '@milaboratories/pl-error-like@1.12.9':
     dependencies:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.2.2':
+  '@milaboratories/pl-errors@1.2.8':
     dependencies:
-      '@milaboratories/pl-client': 2.18.2
-      '@milaboratories/ts-helpers': 1.7.3
-      zod: 3.23.8
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/ts-helpers': 1.8.1
+      zod: 3.25.76
 
   '@milaboratories/pl-http@1.2.4':
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.53.1(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.55.7(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/computable': 2.9.0
-      '@milaboratories/pf-driver': 1.2.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.1.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.15
-      '@milaboratories/pframes-rs-wasm': 1.1.15(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.29.0)(@milaboratories/pl-model-middle-layer@1.16.0)
-      '@milaboratories/pl-client': 2.18.2
-      '@milaboratories/pl-deployments': 2.16.2
-      '@milaboratories/pl-drivers': 1.12.3
-      '@milaboratories/pl-errors': 1.2.2
+      '@milaboratories/computable': 2.9.2
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pf-driver': 1.3.5(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.2.5(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.18
+      '@milaboratories/pframes-rs-wasm': 1.1.18(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.2)(@milaboratories/pl-model-middle-layer@1.16.4)
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/pl-deployments': 2.16.6
+      '@milaboratories/pl-drivers': 1.12.10
+      '@milaboratories/pl-errors': 1.2.8
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.2.2
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
-      '@milaboratories/pl-tree': 1.9.3
+      '@milaboratories/pl-model-backend': 1.2.8
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
+      '@milaboratories/pl-tree': 1.9.9
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.7.3
-      '@platforma-sdk/block-tools': 2.7.2
-      '@platforma-sdk/model': 1.61.1
-      '@platforma-sdk/workflow-tengo': 5.11.0
+      '@milaboratories/ts-helpers': 1.8.1
+      '@platforma-sdk/block-tools': 2.7.7
+      '@platforma-sdk/model': 1.63.12
+      '@platforma-sdk/workflow-tengo': 5.13.1
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.44.0
@@ -6149,7 +6033,7 @@ snapshots:
       undici: 7.16.0
       utility-types: 3.11.0
       yaml: 2.8.2
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - aws-crt
@@ -6159,17 +6043,11 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.2.2':
+  '@milaboratories/pl-model-backend@1.2.8':
     dependencies:
-      '@milaboratories/pl-client': 2.18.2
+      '@milaboratories/pl-client': 3.1.1
       canonicalize: 2.1.0
-      zod: 3.23.8
-
-  '@milaboratories/pl-model-common@1.23.0':
-    dependencies:
-      '@milaboratories/pl-error-like': 1.12.5
-      canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/pl-model-common@1.28.0':
     dependencies:
@@ -6178,19 +6056,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.29.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.0
-      '@milaboratories/pl-error-like': 1.12.9
-      canonicalize: 2.1.0
-      zod: 3.23.8
-
-  '@milaboratories/pl-model-common@1.31.1':
+  '@milaboratories/pl-model-common@1.31.2':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.15.0':
     dependencies:
@@ -6200,39 +6071,27 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.16.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.0
-      '@milaboratories/pl-model-common': 1.29.0
-      es-toolkit: 1.44.0
-      utility-types: 3.11.0
-      zod: 3.23.8
-
-  '@milaboratories/pl-model-middle-layer@1.16.3':
+  '@milaboratories/pl-model-middle-layer@1.16.4':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.31.1
+      '@milaboratories/pl-model-common': 1.31.2
       es-toolkit: 1.44.0
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.9.3':
+  '@milaboratories/pl-tree@1.9.9':
     dependencies:
-      '@milaboratories/computable': 2.9.0
-      '@milaboratories/pl-client': 2.18.2
-      '@milaboratories/pl-errors': 1.2.2
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/computable': 2.9.2
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/pl-errors': 1.2.8
+      '@milaboratories/ts-helpers': 1.8.1
       denque: 2.1.0
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.1.9':
+  '@milaboratories/ptabler-expression-js@1.2.6':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.13.2
-
-  '@milaboratories/ptabler-expression-js@1.2.2':
-    dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.14.2
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.14.6
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6240,25 +6099,25 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.3.0(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.3.1(@types/node@25.2.0)(esbuild@0.27.2)(rollup@4.57.1)(vue@3.5.27(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.2.2
-      '@vitejs/plugin-vue': 6.0.5(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.27(typescript@5.6.3))
+      '@milaboratories/ts-configs': 1.2.3
+      '@vitejs/plugin-vue': 6.0.5(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.27(typescript@5.6.3))
       commander: 12.1.0
       jsonc-parser: 3.3.1
       oxfmt: 0.35.0
       oxlint: 1.43.0
-      rolldown: 1.0.0-rc.11
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))
+      rolldown: 1.0.0-rc.15
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.2.0)(rollup@4.57.1)
       typescript: 5.9.3
-      vite: 8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
       vite-plugin-commonjs: 0.10.4
-      vite-plugin-dts: 4.5.4(@types/node@25.2.0)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
-      vite-plugin-externalize-deps: 0.9.0(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
-      vite-plugin-lib-inject-css: 2.2.2(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
-      vue-tsc: 2.2.12(typescript@5.9.3)
+      vite-plugin-dts: 4.5.4(@types/node@25.2.0)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
+      vite-plugin-externalize-deps: 0.10.0(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
+      vite-plugin-lib-inject-css: 2.2.2(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
+      vue-tsc: 3.2.6(typescript@5.9.3)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@types/node'
@@ -6280,22 +6139,12 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-configs@1.2.2': {}
-
-  '@milaboratories/ts-helpers-oclif@1.1.38':
-    dependencies:
-      '@milaboratories/ts-helpers': 1.7.3
-      '@oclif/core': 4.8.0
+  '@milaboratories/ts-configs@1.2.3': {}
 
   '@milaboratories/ts-helpers-oclif@1.1.40':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.8.0
-
-  '@milaboratories/ts-helpers@1.7.3':
-    dependencies:
-      canonicalize: 2.1.0
-      denque: 2.1.0
 
   '@milaboratories/ts-helpers@1.8.1':
     dependencies:
@@ -6303,10 +6152,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.11.3(typescript@5.6.3)':
+  '@milaboratories/uikit@2.11.8(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.0
-      '@platforma-sdk/model': 1.61.1
+      '@milaboratories/helpers': 1.14.1
+      '@platforma-sdk/model': 1.63.12
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6337,14 +6186,16 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6381,11 +6232,7 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@oxc-project/runtime@0.114.0': {}
-
-  '@oxc-project/types@0.114.0': {}
-
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.124.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     optional: true
@@ -6561,11 +6408,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@platforma-open/milaboratories.mixcr-clonotyping-2.model@1.23.0':
-    dependencies:
-      '@platforma-sdk/model': 1.51.6
-      zod: 3.23.8
-
   '@platforma-open/milaboratories.runenv-python-3.10.11@1.1.16': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.1.16': {}
@@ -6583,13 +6425,9 @@ snapshots:
 
   '@platforma-open/milaboratories.software-mixcr@4.7.0-343-develop': {}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.13.2':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.14.6':
     dependencies:
-      '@milaboratories/pl-model-common': 1.23.0
-
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.2':
-    dependencies:
-      '@milaboratories/pl-model-common': 1.29.0
+      '@milaboratories/pl-model-common': 1.31.2
 
   '@platforma-open/milaboratories.software-ptabler@1.15.0': {}
 
@@ -6599,48 +6437,27 @@ snapshots:
 
   '@platforma-open/milaboratories.software-repseqio@2.5.0-25-master': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.9': {}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.5': {}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.3': {}
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.3': {}
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.2':
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     dependencies:
-      '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.5
-      '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.9
-      '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.3
-      '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.3
+      '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
+      '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
+      '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.7.2':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.7.3
-      '@milaboratories/ts-helpers-oclif': 1.1.38
-      '@oclif/core': 4.8.0
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      lru-cache: 11.2.5
-      mime-types: 2.1.35
-      tar: 7.5.7
-      undici: 7.16.0
-      yaml: 2.8.2
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@platforma-sdk/block-tools@2.7.5':
+  '@platforma-sdk/block-tools@2.7.7':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/pl-model-middle-layer': 1.16.3
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.1
       '@milaboratories/ts-helpers-oclif': 1.1.40
@@ -6652,7 +6469,7 @@ snapshots:
       tar: 7.5.7
       undici: 7.16.0
       yaml: 2.8.2
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
 
@@ -6671,28 +6488,18 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.54.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.51.6':
+  '@platforma-sdk/model@1.63.12':
     dependencies:
-      '@milaboratories/pl-error-like': 1.12.5
-      '@milaboratories/pl-model-common': 1.23.0
-      '@milaboratories/ptabler-expression-js': 1.1.9
-      canonicalize: 2.1.0
-      es-toolkit: 1.44.0
-      utility-types: 3.11.0
-      zod: 3.23.8
-
-  '@platforma-sdk/model@1.61.1':
-    dependencies:
-      '@milaboratories/helpers': 1.14.0
+      '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
-      '@milaboratories/pl-model-common': 1.29.0
-      '@milaboratories/pl-model-middle-layer': 1.16.0
-      '@milaboratories/ptabler-expression-js': 1.2.2
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/pl-model-middle-layer': 1.16.4
+      '@milaboratories/ptabler-expression-js': 1.2.6
       canonicalize: 2.1.0
       es-toolkit: 1.44.0
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@platforma-sdk/package-builder@3.12.0':
     dependencies:
@@ -6712,23 +6519,24 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@2.5.2':
+  '@platforma-sdk/tengo-builder@2.5.8':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.2
+      '@milaboratories/pl-model-backend': 1.2.8
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.7.3
+      '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.8.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.61.1(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)':
+  '@platforma-sdk/test@1.63.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.2.0)(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.0
-      '@milaboratories/pl-client': 2.18.2
-      '@milaboratories/pl-middle-layer': 1.53.1(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.9.3
-      '@vitest/coverage-istanbul': 4.0.18(vitest@4.0.18(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2))
-      vitest: 4.0.18(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      '@milaboratories/computable': 2.9.2
+      '@milaboratories/pl-client': 3.1.1
+      '@milaboratories/pl-middle-layer': 1.55.7(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.9.9
+      '@platforma-sdk/model': 1.63.12
+      '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
+      vitest: 4.1.4(@types/node@25.2.0)(@vitest/coverage-istanbul@4.1.4(vitest@3.2.4(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -6737,31 +6545,25 @@ snapshots:
       - '@vitest/browser-playwright'
       - '@vitest/browser-preview'
       - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-v8'
       - '@vitest/ui'
       - aws-crt
       - bare-abort-controller
       - bare-buffer
       - encoding
       - happy-dom
-      - jiti
       - jsdom
-      - less
-      - lightningcss
       - msw
       - react-native-b4a
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
       - supports-color
-      - terser
-      - tsx
-      - yaml
+      - vite
 
-  '@platforma-sdk/ui-vue@1.61.1(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.63.12(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/uikit': 2.11.3(typescript@5.6.3)
-      '@platforma-sdk/model': 1.61.1
+      '@milaboratories/pf-spec-driver': 1.2.5(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.31.2
+      '@milaboratories/uikit': 2.11.8(typescript@5.6.3)
+      '@platforma-sdk/model': 1.63.12
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -6775,8 +6577,9 @@ snapshots:
       fast-json-patch: 3.1.1
       lru-cache: 11.2.5
       vue: 3.5.27(typescript@5.6.3)
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
       - async-validator
       - axios
       - change-case
@@ -6790,12 +6593,12 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.11.0':
+  '@platforma-sdk/workflow-tengo@5.13.1':
     dependencies:
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.15.0
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
     dependencies:
@@ -6845,99 +6648,58 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.11':
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.5':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.5':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.5':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.5':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.5':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.5':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.5':
-    optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.11': {}
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.5': {}
 
   '@rollup/pluginutils@5.2.0(rollup@4.57.1)':
     dependencies:
@@ -7421,7 +7183,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7603,25 +7365,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.5(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.27(typescript@5.6.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.27(typescript@5.6.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
       vue: 3.5.27(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.0.18(vitest@4.0.18(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/coverage-istanbul@4.1.4(vitest@4.1.4)':
     dependencies:
+      '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.1
+      magicast: 0.5.2
       obug: 2.1.1
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@25.2.0)(@vitest/coverage-istanbul@4.1.4(vitest@3.2.4(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -7633,14 +7395,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
@@ -7650,21 +7412,21 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -7672,9 +7434,9 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
   '@vitest/snapshot@3.2.4':
@@ -7683,9 +7445,10 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -7693,7 +7456,7 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -7701,28 +7464,17 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
-
-  '@volar/language-core@2.4.15':
-    dependencies:
-      '@volar/source-map': 2.4.15
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
 
-  '@volar/source-map@2.4.15': {}
-
   '@volar/source-map@2.4.28': {}
-
-  '@volar/typescript@2.4.15':
-    dependencies:
-      '@volar/language-core': 2.4.15
-      path-browserify: 1.0.1
-      vscode-uri: 3.1.0
 
   '@volar/typescript@2.4.28':
     dependencies:
@@ -7778,18 +7530,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@2.2.12(typescript@5.9.3)':
+  '@vue/language-core@3.2.6':
     dependencies:
-      '@volar/language-core': 2.4.15
+      '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.27
-      '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.27
-      alien-signals: 1.0.13
-      minimatch: 9.0.5
+      alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.9.3
+      picomatch: 4.0.3
 
   '@vue/reactivity@3.5.27':
     dependencies:
@@ -7929,7 +7678,7 @@ snapshots:
 
   alien-signals@0.4.14: {}
 
-  alien-signals@1.0.13: {}
+  alien-signals@3.1.2: {}
 
   ansi-colors@4.1.3: {}
 
@@ -7994,7 +7743,7 @@ snapshots:
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.3
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -8421,6 +8170,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -8930,16 +8681,6 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@6.0.3:
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
@@ -9133,7 +8874,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.1:
+  magicast@0.5.2:
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
@@ -9367,6 +9108,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -9408,6 +9151,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -9528,63 +9277,45 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
-      '@babel/generator': 8.0.0-rc.2
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/generator': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3
       get-tsconfig: 4.13.7
       obug: 2.1.1
-      rolldown: 1.0.0-rc.11
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.15
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 2.2.12(typescript@5.9.3)
+      vue-tsc: 3.2.6(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.11:
+  rolldown@1.0.0-rc.15:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.11
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.11
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.11
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.11
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.11
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.11
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.11
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.11
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
-
-  rolldown@1.0.0-rc.5:
-    dependencies:
-      '@oxc-project/types': 0.114.0
-      '@rolldown/pluginutils': 1.0.0-rc.5
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.5
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.5
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.5
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.5
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.5
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.5
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.5
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.5
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.5
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.5
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.5
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.5
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   rollup-plugin-copy@3.5.0:
     dependencies:
@@ -9731,6 +9462,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.0.0: {}
+
   stream-browserify@3.0.0:
     dependencies:
       inherits: 2.0.4
@@ -9871,7 +9604,7 @@ snapshots:
 
   tinyrainbow@2.0.0: {}
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -9895,7 +9628,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@5.6.3):
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       typescript: 5.6.3
 
   tslib@1.14.1: {}
@@ -10034,7 +9767,7 @@ snapshots:
       magic-string: 0.30.21
       vite-plugin-dynamic-import: 1.6.0
 
-  vite-plugin-dts@4.5.4(@types/node@25.2.0)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
+  vite-plugin-dts@4.5.4(@types/node@25.2.0)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@25.2.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
@@ -10047,7 +9780,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -10060,16 +9793,16 @@ snapshots:
       fast-glob: 3.3.3
       magic-string: 0.30.21
 
-  vite-plugin-externalize-deps@0.9.0(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
+  vite-plugin-externalize-deps@0.10.0(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
-      vite: 8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
 
-  vite-plugin-lib-inject-css@2.2.2(vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
+  vite-plugin-lib-inject-css@2.2.2(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
       '@ast-grep/napi': 0.36.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
 
   vite@7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2):
     dependencies:
@@ -10085,13 +9818,12 @@ snapshots:
       lightningcss: 1.32.0
       yaml: 2.8.2
 
-  vite@8.0.0-beta.15(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2):
+  vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2):
     dependencies:
-      '@oxc-project/runtime': 0.114.0
       lightningcss: 1.32.0
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rolldown: 1.0.0-rc.5
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.2.0
@@ -10140,42 +9872,33 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2):
+  vitest@4.1.4(@types/node@25.2.0)(@vitest/coverage-istanbul@4.1.4(vitest@3.2.4(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.2.0)(lightningcss@1.32.0)(yaml@2.8.2)
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.2.0)(esbuild@0.27.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.0
+      '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-uri@3.1.0: {}
 
@@ -10194,10 +9917,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@2.2.12(typescript@5.9.3):
+  vue-tsc@3.2.6(typescript@5.9.3):
     dependencies:
-      '@volar/typescript': 2.4.15
-      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.6
       typescript: 5.9.3
 
   vue@3.5.27(typescript@5.6.3):
@@ -10322,5 +10045,7 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@3.23.8: {}
+
+  zod@3.25.76: {}
 
   zod@4.1.12: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,17 +8,17 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.3.0
-  '@milaboratories/ts-configs': 1.2.2
-  '@platforma-sdk/workflow-tengo': 5.11.0
-  '@platforma-sdk/model': 1.61.1
-  '@platforma-sdk/ui-vue': 1.61.1
-  '@platforma-sdk/tengo-builder': 2.5.2
+  '@milaboratories/ts-builder': 1.3.1
+  '@milaboratories/ts-configs': 1.2.3
+  '@platforma-sdk/workflow-tengo': 5.13.1
+  '@platforma-sdk/model': 1.63.12
+  '@platforma-sdk/ui-vue': 1.63.12
+  '@platforma-sdk/tengo-builder': 2.5.8
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.5
+  '@platforma-sdk/block-tools': 2.7.7
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.61.1
-  '@milaboratories/helpers': 1.14.0
+  '@platforma-sdk/test': 1.63.13
+  '@milaboratories/helpers': 1.14.1
 
   # Common dependencies - can use ^ or ~
   'vue': ^3.5.12
@@ -28,6 +28,7 @@ catalog:
   'shx': ^0.4.0
   'eslint': ^9.25.1
   '@changesets/cli': ^2.27.9
+  'zod': ~3.23.8
 
   # Block-specific dependencies
   "@platforma-open/milaboratories.runenv-python-3": 1.4.16
@@ -36,7 +37,6 @@ catalog:
   "@platforma-open/milaboratories.software-mixcr": 4.7.0-343-develop
   "@platforma-open/milaboratories.software-ptransform": ^1.6.6
   '@platforma-open/milaboratories.software-repseqio': ^2.5.0-13-master
-  "@platforma-open/milaboratories.mixcr-clonotyping-2.model": ^1.9.0
   'ag-grid-enterprise': &ag-grid ~34.1.2
   'ag-grid-vue3': *ag-grid
   '@zip.js/zip.js': ^2.8.2

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
     },
     "build": {
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV"],
+      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"],
       "dependsOn": ["type-check", "lint", "^build"],
       "passThroughEnv": ["PL_DOCKER_REGISTRY_PUSH_TO"]
@@ -23,7 +23,14 @@
     },
     "test": {
       "dependsOn": ["build"],
-      "passThroughEnv": ["PL_ADDRESS", "PL_TEST_PASSWORD", "PL_TEST_USER", "PL_TEST_PROXY", "DEBUG", "PL_DOCKER_REGISTRY_PUSH_TO"]
+      "passThroughEnv": [
+        "PL_ADDRESS",
+        "PL_TEST_PASSWORD",
+        "PL_TEST_USER",
+        "PL_TEST_PROXY",
+        "DEBUG",
+        "PL_DOCKER_REGISTRY_PUSH_TO"
+      ]
     },
     "mark-stable": {
       "passThroughEnv": ["PL_REGISTRY", "AWS_*", "PL_DOCKER_REGISTRY_PUSH_TO"],

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,6 @@
     "ag-grid-enterprise": "catalog:",
     "ag-grid-vue3": "catalog:",
     "@milaboratories/helpers": "catalog:",
-    "@platforma-open/milaboratories.mixcr-clonotyping-2.model": "catalog:",
     "@platforma-open/milaboratories.mixcr-scfv-clonotyping.model": "workspace:*",
     "@platforma-sdk/ui-vue": "catalog:",
     "@platforma-sdk/model": "catalog:",

--- a/ui/src/ExportRawBtn/ExportRawBtn.vue
+++ b/ui/src/ExportRawBtn/ExportRawBtn.vue
@@ -85,7 +85,7 @@ const exportRawTsvs = async () => {
         'application/zip': ['.zip'],
       },
     }],
-    suggestedName: `${new Date().toISOString().split('T')[0]}_ScFvClonotypingResultsRaw_${app.model.args.title ?? 'Untitled'}.zip`,
+    suggestedName: `${new Date().toISOString().split('T')[0]}_ScFvClonotypingResultsRaw_${app.model.data.title ?? 'Untitled'}.zip`,
   });
 
   data.loading = true;

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -1,14 +1,11 @@
-import { model } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
+import { platforma } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import { defineAppV3 } from '@platforma-sdk/ui-vue';
 import MainPage from './pages/MainPage.vue';
 import QcReportTablePage from './pages/QcReportTablePage.vue';
 import { watch } from 'vue';
 
-export const sdkPlugin = defineAppV3(model, (app) => {
+export const sdkPlugin = defineAppV3(platforma, () => {
   return {
-    progress: () => {
-      return app.model.outputs.isRunning;
-    },
     showErrorsNotification: true,
     routes: {
       '/': () => MainPage,

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -1,10 +1,10 @@
 import { model } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
-import { defineApp } from '@platforma-sdk/ui-vue';
+import { defineAppV3 } from '@platforma-sdk/ui-vue';
 import MainPage from './pages/MainPage.vue';
 import QcReportTablePage from './pages/QcReportTablePage.vue';
 import { watch } from 'vue';
 
-export const sdkPlugin = defineApp(model, (app) => {
+export const sdkPlugin = defineAppV3(model, (app) => {
   return {
     progress: () => {
       return app.model.outputs.isRunning;
@@ -23,7 +23,7 @@ export const useApp = sdkPlugin.useApp;
 const unwatch = watch(sdkPlugin, ({ loaded }) => {
   if (!loaded) return;
   const app = useApp();
-  app.model.args.customBlockLabel ??= '';
-  app.model.args.defaultBlockLabel ??= 'Select Dataset';
+  app.model.data.customBlockLabel ??= '';
+  app.model.data.defaultBlockLabel ??= 'Select Dataset';
   unwatch();
 });

--- a/ui/src/charts/AlignmentsChart.vue
+++ b/ui/src/charts/AlignmentsChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AlignReport } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
+import type { AlignReport } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import {
   PlChartStackedBar,
 } from '@platforma-sdk/ui-vue';

--- a/ui/src/charts/ChainsChart.vue
+++ b/ui/src/charts/ChainsChart.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { AlignReport } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
+import type { AlignReport } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import { computed } from 'vue';
 import { PlChartStackedBar } from '@platforma-sdk/ui-vue';
 import { useChainsChartSettings } from './chainsChartSettings';

--- a/ui/src/charts/alignmentChartSettings.ts
+++ b/ui/src/charts/alignmentChartSettings.ts
@@ -1,5 +1,5 @@
-import type { AlignReport } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
-import { AlignmentChannelLabels, extractAlignmentChannels } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
+import type { AlignReport } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
+import { AlignmentChannelLabels, extractAlignmentChannels } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import type {
   Color,
 } from '@platforma-sdk/ui-vue';

--- a/ui/src/charts/chainsChartSettings.ts
+++ b/ui/src/charts/chainsChartSettings.ts
@@ -1,5 +1,5 @@
-import type { AlignReport } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
-import { AlignmentChainColors, ImmuneChains } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
+import type { AlignReport } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
+import { AlignmentChainColors, ImmuneChains } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import type {
   PlChartStackedBarSettings,
 } from '@platforma-sdk/ui-vue';

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -37,13 +37,13 @@ const app = useApp();
 watchEffect(() => {
   const parts: string[] = [];
   // Add dataset name if available
-  if (app.model.args.input) {
-    const inputOption = app.model.outputs.inputOptions?.find((p) => app.model.args.input && plRefsEqual(p.ref, app.model.args.input));
+  if (app.model.data.input) {
+    const inputOption = app.model.outputs.inputOptions?.find((p) => app.model.data.input && plRefsEqual(p.ref, app.model.data.input));
     if (inputOption?.label) {
       parts.push(inputOption.label);
     }
   }
-  app.model.args.defaultBlockLabel = parts.filter(Boolean).join(' - ') || 'Select Dataset';
+  app.model.data.defaultBlockLabel = parts.filter(Boolean).join(' - ') || 'Select Dataset';
 });
 
 const rows = computed(() =>
@@ -92,7 +92,7 @@ const defaultColumnDef: ColDef = {
   sortable: false,
 };
 
-const hideLightProgress = computed(() => Boolean(app.model.args.lightImputeSequence));
+const hideLightProgress = computed(() => Boolean(app.model.data.lightImputeSequence));
 
 const columnDefs = computed<ColDef<ScFvResult>[]>(() => {
   const cols: ColDef<ScFvResult>[] = [

--- a/ui/src/pages/QcReportTablePage.vue
+++ b/ui/src/pages/QcReportTablePage.vue
@@ -20,7 +20,7 @@ const tableSettings = usePlDataTableSettingsV2({
       QC Report Table
     </template>
     <PlAgDataTableV2
-      v-model="app.model.ui.tableState"
+      v-model="app.model.data.tableState"
       :settings="tableSettings"
       show-columns-panel
       show-export-button

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -8,13 +8,27 @@ import { parseFasta } from '../utils/fastaValidator';
 import { validateFullScFv, validateLibrarySequence, validateSeparateChain, validateLinker, validateHinge } from '../utils/sequenceValidator';
 
 const app = useApp();
-type ArgsExt = typeof app.model.args & { imputeLight?: boolean; lightImputeSequence?: string };
 type StopCodonType = 'amber' | 'ochre' | 'opal';
-const argsExt = app.model.args as ArgsExt;
 const imputeLight = computed<boolean>({
-  get: () => argsExt.imputeLight === true,
-  set: (v: boolean) => { argsExt.imputeLight = v; },
+  get: () => app.model.data.imputeLight === true,
+  set: (v: boolean) => { app.model.data.imputeLight = v; },
 });
+
+const DRY_RUN_READS = 100_000;
+
+const runModeOptions: ListOption<'dry' | 'full'>[] = [
+  { label: 'Preview', value: 'dry' },
+  { label: 'Full run', value: 'full' },
+];
+
+watch(
+  () => app.model.data.runMode,
+  (value) => {
+    if (value === 'dry' && app.model.data.limitInput === undefined) {
+      app.model.data.limitInput = DRY_RUN_READS;
+    }
+  },
+);
 // no separate scFv hinge field; use general hinge in Analysis section
 
 const speciesOptions: ListOption[] = [
@@ -80,7 +94,7 @@ function _plRefsEqual(ref1: PlRef, ref2: PlRef) {
 }
 
 function setInput(inputRef?: PlRef) {
-  app.model.args.input = inputRef;
+  app.model.data.input = inputRef;
 }
 
 const orderOptions: ListOption[] = [
@@ -95,24 +109,24 @@ const clusteringOptions: ListOption[] = [
 ] as const;
 
 const stopCodonSelection = computed({
-  get: () => app.model.args.stopCodonTypes ?? [],
+  get: () => app.model.data.stopCodonTypes ?? [],
   set: (value: StopCodonType[]) => {
-    app.model.args.stopCodonTypes = value.length > 0 ? value : undefined;
+    app.model.data.stopCodonTypes = value.length > 0 ? value : undefined;
   },
 });
 
 const stopCodonReplacementModel = (type: StopCodonType) =>
   computed({
-    get: () => app.model.args.stopCodonReplacements?.[type],
+    get: () => app.model.data.stopCodonReplacements?.[type],
     set: (value: string | undefined) => {
-      const current = app.model.args.stopCodonReplacements ?? {};
+      const current = app.model.data.stopCodonReplacements ?? {};
       if (value === undefined) {
         if (current[type] !== undefined) {
           delete current[type];
         }
-        app.model.args.stopCodonReplacements = Object.keys(current).length > 0 ? current : undefined;
+        app.model.data.stopCodonReplacements = Object.keys(current).length > 0 ? current : undefined;
       } else {
-        app.model.args.stopCodonReplacements = { ...current, [type]: value };
+        app.model.data.stopCodonReplacements = { ...current, [type]: value };
       }
     },
   });
@@ -122,29 +136,29 @@ const ochreReplacement = stopCodonReplacementModel('ochre');
 const opalReplacement = stopCodonReplacementModel('opal');
 
 watch(stopCodonSelection, (selected) => {
-  const current = app.model.args.stopCodonReplacements;
+  const current = app.model.data.stopCodonReplacements;
   if (!current) return;
   const next = { ...current };
   for (const key of Object.keys(next) as StopCodonType[]) {
     if (!selected.includes(key)) delete next[key];
   }
-  app.model.args.stopCodonReplacements = Object.keys(next).length > 0 ? next : undefined;
+  app.model.data.stopCodonReplacements = Object.keys(next).length > 0 ? next : undefined;
 });
 
 const heavyValidation = computed(() => {
-  if (app.model.args.customRefMode === 'separate') {
-    const raw = (app.model.args.heavyChainSequence ?? '').trim();
+  if (app.model.data.customRefMode === 'separate') {
+    const raw = (app.model.data.heavyChainSequence ?? '').trim();
     if (!raw) return undefined;
     return validateSeparateChain(raw);
   }
-  if (app.model.args.customRefMode === 'builtin') return undefined;
+  if (app.model.data.customRefMode === 'builtin') return undefined;
 
-  const scfvRaw = (app.model.args.scFvSequence ?? '').trim();
+  const scfvRaw = (app.model.data.scFvSequence ?? '').trim();
   if (!scfvRaw) return undefined;
   // FASTA format is checked in scFvValidation now
-  const linker = (app.model.args.linker ?? '').toUpperCase().replace(/\s/g, '');
-  const hingeRaw = (app.model.args.hinge ?? '').toUpperCase().replace(/\s/g, '');
-  const order = app.model.args.order ?? 'hl';
+  const linker = (app.model.data.linker ?? '').toUpperCase().replace(/\s/g, '');
+  const hingeRaw = (app.model.data.hinge ?? '').toUpperCase().replace(/\s/g, '');
+  const order = app.model.data.order ?? 'hl';
   if (!linker) return { isValid: false, error: 'Linker sequence is required in scFv mode' };
   let seq = scfvRaw.toUpperCase().replace(/\s/g, '');
   if (hingeRaw) {
@@ -158,18 +172,18 @@ const heavyValidation = computed(() => {
 });
 
 const lightValidation = computed(() => {
-  if (app.model.args.customRefMode === 'separate') {
-    const raw = (app.model.args.lightChainSequence ?? '').trim();
+  if (app.model.data.customRefMode === 'separate') {
+    const raw = (app.model.data.lightChainSequence ?? '').trim();
     if (!raw) return undefined;
     return validateSeparateChain(raw);
   }
-  if (app.model.args.customRefMode === 'builtin') return undefined;
-  const scfvRaw = (app.model.args.scFvSequence ?? '').trim();
+  if (app.model.data.customRefMode === 'builtin') return undefined;
+  const scfvRaw = (app.model.data.scFvSequence ?? '').trim();
   if (!scfvRaw) return undefined;
   // FASTA format is checked in scFvValidation now
-  const linker = (app.model.args.linker ?? '').toUpperCase().replace(/\s/g, '');
-  const hingeRaw = (app.model.args.hinge ?? '').toUpperCase().replace(/\s/g, '');
-  const order = app.model.args.order ?? 'hl';
+  const linker = (app.model.data.linker ?? '').toUpperCase().replace(/\s/g, '');
+  const hingeRaw = (app.model.data.hinge ?? '').toUpperCase().replace(/\s/g, '');
+  const order = app.model.data.order ?? 'hl';
   if (!linker) return { isValid: false, error: 'Linker sequence is required in scFv mode' };
   let seq = scfvRaw.toUpperCase().replace(/\s/g, '');
   if (hingeRaw) {
@@ -184,19 +198,19 @@ const lightValidation = computed(() => {
 
 // Full scFv-level validation (format/linker/split) for scFv mode
 const scFvValidation = computed(() => {
-  if (app.model.args.customRefMode !== 'scFv') return undefined;
-  const scfvRaw = (app.model.args.scFvSequence ?? '').trim();
+  if (app.model.data.customRefMode !== 'scFv') return undefined;
+  const scfvRaw = (app.model.data.scFvSequence ?? '').trim();
   if (!scfvRaw) return undefined;
-  return validateFullScFv(scfvRaw, app.model.args.linker ?? '', app.model.args.hinge, (app.model.args.order as 'hl' | 'lh') ?? 'hl');
+  return validateFullScFv(scfvRaw, app.model.data.linker ?? '', app.model.data.hinge, (app.model.data.order as 'hl' | 'lh') ?? 'hl');
 });
 
 // Validate linker and hinge as plain nt sequences (no FASTA, only A/C/G/T, multiple of 3)
-const linkerValidation = computed(() => validateLinker(app.model.args.linker ?? ''));
-const hingeValidation = computed(() => validateHinge(app.model.args.hinge ?? ''));
+const linkerValidation = computed(() => validateLinker(app.model.data.linker ?? ''));
+const hingeValidation = computed(() => validateHinge(app.model.data.hinge ?? ''));
 
 const umiMismatchWarning = computed(() => {
-  const heavyPattern = app.model.args.heavyTagPattern ?? '';
-  const lightPattern = app.model.args.lightTagPattern ?? '';
+  const heavyPattern = app.model.data.heavyTagPattern ?? '';
+  const lightPattern = app.model.data.lightTagPattern ?? '';
   const heavyHasUmi = /umi/i.test(heavyPattern);
   const lightHasUmi = /umi/i.test(lightPattern);
   if (heavyHasUmi && !lightHasUmi) {
@@ -211,18 +225,18 @@ const umiMismatchWarning = computed(() => {
 // Derive per-chain V/J FASTA strings into args for workflow
 watch(
   () => ({
-    mode: app.model.args.customRefMode,
-    heavy: app.model.args.heavyChainSequence,
-    light: app.model.args.lightChainSequence,
-    scfv: app.model.args.scFvSequence,
-    linker: app.model.args.linker,
-    hinge: app.model.args.hinge,
-    order: app.model.args.order,
-    imputeLight: argsExt.imputeLight,
+    mode: app.model.data.customRefMode,
+    heavy: app.model.data.heavyChainSequence,
+    light: app.model.data.lightChainSequence,
+    scfv: app.model.data.scFvSequence,
+    linker: app.model.data.linker,
+    hinge: app.model.data.hinge,
+    order: app.model.data.order,
+    imputeLight: app.model.data.imputeLight,
   }),
   () => {
     const setVJ = (chain: 'heavy' | 'light', v?: string, j?: string) => {
-      const args = app.model.args as Record<string, unknown>;
+      const args = app.model.data as Record<string, unknown>;
       if (chain === 'heavy') {
         args.heavyVGenes = v;
         args.heavyJGenes = j;
@@ -236,17 +250,17 @@ watch(
     setVJ('heavy', undefined, undefined);
     setVJ('light', undefined, undefined);
     // reset derived impute sequence by default
-    argsExt.lightImputeSequence = undefined;
+    app.model.data.lightImputeSequence = undefined;
 
-    const mode = app.model.args.customRefMode;
+    const mode = app.model.data.customRefMode;
     if (mode === 'builtin') {
       setVJ('heavy', undefined, undefined);
       setVJ('light', undefined, undefined);
       return;
     }
     if (mode === 'separate') {
-      const hv = app.model.args.heavyChainSequence?.trim();
-      const lv = app.model.args.lightChainSequence?.trim();
+      const hv = app.model.data.heavyChainSequence?.trim();
+      const lv = app.model.data.lightChainSequence?.trim();
       if (hv) {
         const hvRecs = hv.startsWith('>') ? parseFasta(hv) : [{ header: 'Heavy', seq: hv }];
         const hvVParts: string[] = [];
@@ -275,19 +289,19 @@ watch(
         }
         setVJ('light', lvVParts.length ? lvVParts.join('\n') : undefined, lvJParts.length ? lvJParts.join('\n') : undefined);
         // if imputing in separate mode, use provided light chain reference as impute sequence
-        if (argsExt.imputeLight === true) {
+        if (app.model.data.imputeLight === true) {
           const seq = (lvRecs[0]?.seq ?? '').toUpperCase().replace(/\s/g, '');
-          argsExt.lightImputeSequence = seq || undefined;
+          app.model.data.lightImputeSequence = seq || undefined;
         }
       }
       return;
     }
 
     // scFv mode: allow multi-record FASTA in scFvSequence
-    const scfvRaw = (app.model.args.scFvSequence ?? '').trim();
-    const hingeRaw = (app.model.args.hinge ?? '').toUpperCase().replace(/\s/g, '');
-    const linker = (app.model.args.linker ?? '').toUpperCase().replace(/\s/g, '');
-    const order = app.model.args.order ?? 'hl';
+    const scfvRaw = (app.model.data.scFvSequence ?? '').trim();
+    const hingeRaw = (app.model.data.hinge ?? '').toUpperCase().replace(/\s/g, '');
+    const linker = (app.model.data.linker ?? '').toUpperCase().replace(/\s/g, '');
+    const order = app.model.data.order ?? 'hl';
     if (!scfvRaw || !linker) return;
 
     const records = scfvRaw.startsWith('>') ? parseFasta(scfvRaw) : [{ header: 'scFv', seq: scfvRaw }];
@@ -338,8 +352,8 @@ watch(
     setVJ('light', lv, lj);
 
     // when imputing light from scFv reference, store the derived nt sequence for workflow
-    if (argsExt.imputeLight === true) {
-      argsExt.lightImputeSequence = firstValidLightSeq;
+    if (app.model.data.imputeLight === true) {
+      app.model.data.lightImputeSequence = firstValidLightSeq;
     }
   },
   { immediate: true, deep: true },
@@ -349,7 +363,7 @@ watch(
 <template>
   <PlDropdownRef
     :options="app.model.outputs.inputOptions"
-    :model-value="app.model.args.input"
+    :model-value="app.model.data.input"
     label="Select dataset"
     clearable required
     @update:model-value="setInput"
@@ -360,7 +374,7 @@ watch(
   </PlDropdownRef>
 
   <PlBtnGroup
-    v-model="app.model.args.customRefMode"
+    v-model="app.model.data.customRefMode"
     :options="[
       { label: 'Built-in reference', value: 'builtin' },
       { label: 'Full scFv sequence', value: 'scFv' },
@@ -378,7 +392,7 @@ watch(
     </template>
   </PlBtnGroup>
 
-  <template v-if="app.model.args.customRefMode === 'separate'">
+  <template v-if="app.model.data.customRefMode === 'separate'">
     <PlAlert
       v-if="(heavyValidation && !heavyValidation.isValid) || (lightValidation && !lightValidation.isValid)"
       type="error"
@@ -388,7 +402,7 @@ watch(
       <div v-if="lightValidation && !lightValidation.isValid">Light chain: {{ lightValidation.error }}</div>
     </PlAlert>
     <PlTextArea
-      v-model="app.model.args.heavyChainSequence"
+      v-model="app.model.data.heavyChainSequence"
       :rows="4"
       label="Heavy chain sequence"
       placeholder=">name
@@ -399,7 +413,7 @@ ATCGATCGATCG..."
       </template>
     </PlTextArea>
     <PlTextArea
-      v-model="app.model.args.lightChainSequence"
+      v-model="app.model.data.lightChainSequence"
       :rows="4"
       label="Light chain sequence"
       placeholder=">name
@@ -411,7 +425,7 @@ ATCGATCGATCG..."
     </PlTextArea>
   </template>
 
-  <template v-else-if="app.model.args.customRefMode === 'scFv'">
+  <template v-else-if="app.model.data.customRefMode === 'scFv'">
     <PlAlert
       v-if="scFvValidation && !scFvValidation.isValid"
       type="error"
@@ -420,7 +434,7 @@ ATCGATCGATCG..."
       {{ scFvValidation.error }}
     </PlAlert>
     <PlTextArea
-      v-model="app.model.args.scFvSequence"
+      v-model="app.model.data.scFvSequence"
       :rows="4"
       label="Full scFv sequence"
       placeholder=">name
@@ -433,8 +447,8 @@ heavy-seq + linker + light-seq (or reverse)"
   </template>
 
   <PlDropdown
-    v-if="app.model.args.customRefMode === 'builtin'"
-    v-model="app.model.args.species"
+    v-if="app.model.data.customRefMode === 'builtin'"
+    v-model="app.model.data.species"
     :options="speciesOptions"
     label="Select species"
     required
@@ -445,7 +459,7 @@ heavy-seq + linker + light-seq (or reverse)"
   </PlDropdown>
 
   <PlDropdown
-    v-model="app.model.args.order"
+    v-model="app.model.data.order"
     :options="orderOptions"
     label="Construct building order"
   >
@@ -467,7 +481,7 @@ heavy-seq + linker + light-seq (or reverse)"
   </PlAlert>
 
   <PlTextArea
-    v-model="app.model.args.linker"
+    v-model="app.model.data.linker"
     :rows="3"
     label="Linker nucleotide sequence"
     placeholder="GGTGGCGGTGGCTCTGGTGGCGGTGGCTCTGGTGGCGGTGGCTCT"
@@ -487,9 +501,9 @@ heavy-seq + linker + light-seq (or reverse)"
   </PlAlert>
 
   <PlTextField
-    v-model="app.model.args.heavyTagPattern"
+    v-model="app.model.data.heavyTagPattern"
     label="Heavy chain tag pattern"
-    :clearable="() => undefined"
+    :clearable="() => ''"
     placeholder="^(R1:*)ggtggcggtggctct*\*"
     required
   >
@@ -505,7 +519,7 @@ heavy-seq + linker + light-seq (or reverse)"
   </PlTextField>
 
   <PlDropdown
-    v-model="app.model.args.heavyAssemblingFeature"
+    v-model="app.model.data.heavyAssemblingFeature"
     :options="assemblingFeatureOptions"
     label="Heavy chain assembling feature"
   >
@@ -514,7 +528,7 @@ heavy-seq + linker + light-seq (or reverse)"
     </template>
   </PlDropdown>
 
-  <template v-if="app.model.args.customRefMode === 'scFv' || app.model.args.customRefMode === 'separate'">
+  <template v-if="app.model.data.customRefMode === 'scFv' || app.model.data.customRefMode === 'separate'">
     <PlCheckbox
       v-model="imputeLight"
     >
@@ -523,11 +537,11 @@ heavy-seq + linker + light-seq (or reverse)"
   </template>
 
   <PlTextField
-    v-model="app.model.args.lightTagPattern"
+    v-model="app.model.data.lightTagPattern"
     label="Light chain tag pattern"
-    :clearable="() => undefined"
+    :clearable="() => ''"
     placeholder="^*gcggaagt(R1:*)\^*gactcggatc(R2:*)"
-    :disabled="app.model.args.customRefMode === 'scFv' && imputeLight === true || app.model.args.customRefMode === 'separate' && imputeLight === true"
+    :disabled="app.model.data.customRefMode === 'scFv' && imputeLight === true || app.model.data.customRefMode === 'separate' && imputeLight === true"
   >
     <template #tooltip>
       <p>This critical parameter tells the aligner where to locate the chain's sequence within the raw sequencing read(s). It uses a specific syntax to define the structure of the reads to isolate the relevant part of the read for alignment, ignoring adapters, UMIs, or other non-antibody sequences.</p>
@@ -541,10 +555,10 @@ heavy-seq + linker + light-seq (or reverse)"
   </PlTextField>
 
   <PlDropdown
-    v-model="app.model.args.lightAssemblingFeature"
+    v-model="app.model.data.lightAssemblingFeature"
     :options="assemblingFeatureOptions"
     label="Light chain assembling feature"
-    :disabled="app.model.args.customRefMode === 'scFv' && imputeLight === true || app.model.args.customRefMode === 'separate' && imputeLight === true"
+    :disabled="app.model.data.customRefMode === 'scFv' && imputeLight === true || app.model.data.customRefMode === 'separate' && imputeLight === true"
   >
     <template #tooltip>
       Specifies the portion of the variable chain that your sequencing protocol is expected to cover. Setting this correctly helps anchor the alignment (e.g. FR1-FR4 for full-length, CDR3 for protocols targeting CDR3).
@@ -559,7 +573,7 @@ heavy-seq + linker + light-seq (or reverse)"
     {{ hingeValidation.error }}
   </PlAlert>
   <PlTextArea
-    v-model="app.model.args.hinge"
+    v-model="app.model.data.hinge"
     :rows="3"
     label="Hinge region nt sequence"
   >
@@ -568,10 +582,31 @@ heavy-seq + linker + light-seq (or reverse)"
     </template>
   </PlTextArea>
 
+  <PlBtnGroup v-model="app.model.data.runMode" :options="runModeOptions" label="Run mode">
+    <template #tooltip>
+      Preview — runs the analysis on a small fraction of reads per sample. Use it to check that settings are correct and results look reasonable before launching a full run, which may take much longer.
+    </template>
+  </PlBtnGroup>
+
+  <template v-if="app.model.data.runMode === 'dry'">
+    <PlNumberField
+      v-model="app.model.data.limitInput"
+      label="Reads per sample limit"
+      :clearable="true"
+      :minValue="1"
+      :error-message="app.model.data.limitInput == null ? 'Read limit is required for Preview mode' : undefined"
+    >
+      <template #tooltip>
+        Number of reads to use per sample in the dry run.
+        Recommended: 100,000.
+      </template>
+    </PlNumberField>
+  </template>
+
   <PlAccordionSection label="Advanced Settings">
     <PlSectionSeparator>MiXCR Settings</PlSectionSeparator>
     <PlDropdown
-      v-model="app.model.args.cloneClusteringMode"
+      v-model="app.model.data.cloneClusteringMode"
       :options="clusteringOptions"
       label="Error correction"
     >
@@ -583,12 +618,6 @@ heavy-seq + linker + light-seq (or reverse)"
         </ul>
       </template>
     </PlDropdown>
-    <PlNumberField
-      v-model="app.model.args.limitInput"
-      label="Take only this number of reads into analysis"
-      :clearable="true"
-      :minValue="1"
-    />
     <PlSectionSeparator>Stop codon replacement</PlSectionSeparator>
     <PlDropdownMulti
       v-model="stopCodonSelection"
@@ -623,7 +652,7 @@ heavy-seq + linker + light-seq (or reverse)"
     />
     <PlSectionSeparator>Resource Allocation</PlSectionSeparator>
     <PlNumberField
-      v-model="app.model.args.mixcrCpu"
+      v-model="app.model.data.mixcrCpu"
       label="MiXCR CPU (cores)"
       :min-value="1"
       :step="1"
@@ -634,7 +663,7 @@ heavy-seq + linker + light-seq (or reverse)"
       </template>
     </PlNumberField>
     <PlNumberField
-      v-model="app.model.args.mixcrMem"
+      v-model="app.model.data.mixcrMem"
       label="MiXCR Memory (GiB)"
       :min-value="1"
       :step="1"
@@ -645,7 +674,7 @@ heavy-seq + linker + light-seq (or reverse)"
       </template>
     </PlNumberField>
     <PlNumberField
-      v-model="app.model.args.assembleScfvCpu"
+      v-model="app.model.data.assembleScfvCpu"
       label="Assemble scFv CPU (cores)"
       :min-value="1"
       :step="1"
@@ -656,7 +685,7 @@ heavy-seq + linker + light-seq (or reverse)"
       </template>
     </PlNumberField>
     <PlNumberField
-      v-model="app.model.args.assembleScfvMem"
+      v-model="app.model.data.assembleScfvMem"
       label="Assemble scFv Memory (GiB)"
       :min-value="1"
       :step="1"

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -584,7 +584,7 @@ heavy-seq + linker + light-seq (or reverse)"
 
   <PlBtnGroup v-model="app.model.data.runMode" :options="runModeOptions" label="Run mode">
     <template #tooltip>
-      Preview — runs the analysis on a small fraction of reads per sample. Use it to check that settings are correct and results look reasonable before launching a full run, which may take much longer.
+      Preview — runs the analysis on a small fraction of reads per sample. Use it to check that settings are correct before processing the whole dataset.
     </template>
   </PlBtnGroup>
 

--- a/ui/src/pages/SettingsPanel.vue
+++ b/ui/src/pages/SettingsPanel.vue
@@ -24,7 +24,7 @@ const runModeOptions: ListOption<'dry' | 'full'>[] = [
 watch(
   () => app.model.data.runMode,
   (value) => {
-    if (value === 'dry' && app.model.data.limitInput === undefined) {
+    if (value === 'dry' && app.model.data.limitInput == null) {
       app.model.data.limitInput = DRY_RUN_READS;
     }
   },

--- a/ui/src/parseProgress.ts
+++ b/ui/src/parseProgress.ts
@@ -1,4 +1,4 @@
-import { ProgressPattern } from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
+import { ProgressPattern } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 
 type ParsedProgress = {
   raw?: string;

--- a/ui/src/results.ts
+++ b/ui/src/results.ts
@@ -1,8 +1,8 @@
 import {
   AlignReport,
   AssembleReport,
-} from '@platforma-open/milaboratories.mixcr-clonotyping-2.model';
-import { ProgressPrefix } from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
+  ProgressPrefix,
+} from '@platforma-open/milaboratories.mixcr-scfv-clonotyping.model';
 import { isLiveLog, type AnyLogHandle } from '@platforma-sdk/model';
 import { ReactiveFileContent } from '@platforma-sdk/ui-vue';
 import { computed } from 'vue';
@@ -92,15 +92,15 @@ export const resultMap = computed(() => {
               // globally cached
               chainResult.alignReport = reactiveFileContent.getContentJson(
                 report.value.handle,
-                AlignReport,
-              )?.value;
+                AlignReport as never,
+              )?.value as AlignReport | undefined;
               break;
             case 'assemble':
               // globally cached
               chainResult.assembleReport = reactiveFileContent.getContentJson(
                 report.value.handle,
-                AssembleReport,
-              )?.value;
+                AssembleReport as never,
+              )?.value as AssembleReport | undefined;
               break;
           }
         }

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -412,11 +412,16 @@ self.body(func(inputs) {
 				referenceLibraryHeavy: inputs.referenceLibraryHeavy,
 				referenceLibraryLight: inputs.referenceLibraryLight,
 				truncateFR4: truncateFR4,
+				cloneClusteringMode: inputs.cloneClusteringMode
+			},
+
+			// by passing those parameters as meta fields we allow for recovery and deduplication mechanisms
+			// to pick up the results from executions with different values for CPU and Memory overrides
+			metaExtra: {
 				mixcrCpu: inputs.mixcrCpu,
 				mixcrMem: inputs.mixcrMem,
 				assembleScfvCpu: inputs.assembleScfvCpu,
-				assembleScfvMem: inputs.assembleScfvMem,
-				cloneClusteringMode: inputs.cloneClusteringMode
+				assembleScfvMem: inputs.assembleScfvMem
 			}
 		}
 	)


### PR DESCRIPTION
Migrates the scFv block to BlockModelV3 and adds a Preview/Dry run mode (MiXCR on 100k reads per sample) so users can verify settings before a full run.

- Rewrites the model with `DataModelBuilder` + `BlockModelV3` and a `runMode` field (`'dry' | 'full'`)
- Breaks the runtime dep on `mixcr-clonotyping-2.model` that forced API v2 and produced `Block requested API version 2 but runtime API version is 3` — copies the shared zod schemas into `model/src/reports.ts`
- Bumps `@platforma-sdk/*` catalog to 1.63.12
- Aligns with the `mixcr-amplicon-alignment` V3 reference: renames the model export to `platforma`, extracts progress constants into `model/src/progress.ts`, adds an `Href` type export, and drops the non-idiomatic `progress` callback from `defineAppV3`