### PR TITLE
Fix referenceLibrary.json permission-denied on localfs backend

### DIFF
--- a/.changeset/fix-reference-library-permission-denied.md
+++ b/.changeset/fix-reference-library-permission-denied.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow': patch
+---
+
+Fix `FileNotFoundException: referenceLibrary.json (Permission denied)` when running on the localfs backend. The reference-library workflow invoked `repseqio inferPoints` and `repseqio compile` with the same path for input and output (`referenceLibrary.json`). On localfs, input files are mounted read-only, so the tool could read them but the final write back failed. The output is now written to a separate file (`referenceLibrary.out.json`).

--- a/workflow/src/repseqio-library.tpl.tengo
+++ b/workflow/src/repseqio-library.tpl.tengo
@@ -74,15 +74,15 @@ self.body(func(inputs) {
         arg("--force").
         addFile("referenceLibrary.json", referenceLibrary).
         arg("referenceLibrary.json").
-        arg("referenceLibrary.json").
-        saveFile("referenceLibrary.json").
+        arg("referenceLibrary.out.json").
+        saveFile("referenceLibrary.out.json").
         writeFile("vGene.fasta", vGene).
         cpu(1).
         mem("4GB").
         cacheHours(24)
 
     repseqioInferPointsVResult := repseqioInferPointsVCmd.run()
-    referenceLibraryV := repseqioInferPointsVResult.getFile("referenceLibrary.json")
+    referenceLibraryV := repseqioInferPointsVResult.getFile("referenceLibrary.out.json")
 
     // inferPoints for J
     repseqioInferPointsJCmd := exec.builder().
@@ -93,15 +93,15 @@ self.body(func(inputs) {
         arg("--force").
         addFile("referenceLibrary.json", referenceLibraryV).
         arg("referenceLibrary.json").
-        arg("referenceLibrary.json").
-        saveFile("referenceLibrary.json").
+        arg("referenceLibrary.out.json").
+        saveFile("referenceLibrary.out.json").
         writeFile("jGene.fasta", jGene).
         cpu(1).
         mem("4GB").
         cacheHours(24)
 
     repseqioInferPointsJResult := repseqioInferPointsJCmd.run()
-    referenceLibraryJ := repseqioInferPointsJResult.getFile("referenceLibrary.json")
+    referenceLibraryJ := repseqioInferPointsJResult.getFile("referenceLibrary.out.json")
 
     // compile the library
     repseqioCompileCmd := exec.builder().
@@ -110,8 +110,8 @@ self.body(func(inputs) {
         arg("--force").
         addFile("referenceLibrary.json", referenceLibraryJ).
         arg("referenceLibrary.json").
-        arg("referenceLibrary.json").
-        saveFile("referenceLibrary.json").
+        arg("referenceLibrary.out.json").
+        saveFile("referenceLibrary.out.json").
         writeFile("vGene.fasta", vGene).
         writeFile("jGene.fasta", jGene).
         cpu(1).
@@ -119,7 +119,7 @@ self.body(func(inputs) {
         cacheHours(24)
 
     repseqioCompileResult := repseqioCompileCmd.run()
-    referenceLibraryCompiled := repseqioCompileResult.getFile("referenceLibrary.json")
+    referenceLibraryCompiled := repseqioCompileResult.getFile("referenceLibrary.out.json")
 
     return {
         referenceLibrary: referenceLibraryCompiled


### PR DESCRIPTION
## Summary
- `repseqio inferPoints` (V and J) and `repseqio compile` were called with the same path `referenceLibrary.json` for both input and output. On the localfs backend input files are mounted read-only, so the JVM read the file fine but failed to open it for writing — `FileNotFoundException: referenceLibrary.json (Permission denied)`. This broke the scFv clonotyping block end-to-end on localfs.
- Each step now writes to `referenceLibrary.out.json` and feeds that into the next step (still mounted as `referenceLibrary.json` input). No tool changes required.

Same fix as platforma-open/mixcr-amplicon-alignment#81 — the bug pattern was identical (shared template structure between the two blocks).

## Test plan
- [ ] Run scFv clonotyping block on a localfs backend with a tiny dataset and verify the reference-library template completes without `Permission denied`.
- [ ] Confirm downstream alignment steps still receive a valid compiled `referenceLibrary.json` (no breakage in `mixcr-analyze`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)