### PR TITLE
fix: remove stale pl-pkg prepublish script from software package

### DIFF
--- a/.changeset/fix-stale-prepublish-script.md
+++ b/.changeset/fix-stale-prepublish-script.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.assemble-scfv': patch
+---
+
+Remove stale `pl-pkg prepublish` script left over from the structurer migration. The script survived migration because the structurer only deletes `prepublishOnly`, not the legacy `prepublish` name; with `@platforma-sdk/package-builder` no longer a dependency, `pl-pkg` was not found at publish time. Software build + push now happen in `block-tools software build`, so no prepublish step is needed.

--- a/software/package.json
+++ b/software/package.json
@@ -8,7 +8,6 @@
   "type": "module",
   "scripts": {
     "build": "block-tools software build",
-    "prepublish": "pl-pkg prepublish",
     "do-pack": "shx rm -f *.tgz && block-tools software build && pnpm pack && shx mv platforma-open*.tgz package.tgz",
     "changeset": "changeset",
     "version-packages": "changeset version"


### PR DESCRIPTION
The structurer migration swapped package-builder for block-tools but left the legacy 'prepublish: pl-pkg prepublish' script in place (its refresh rule only deletes 'prepublishOnly'). With package-builder gone, pl-pkg is not found at publish time. Build + push now happen in 'block-tools software build', so no prepublish step is needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes software-package publication by removing an obsolete lifecycle hook.
- Removes the stale `prepublish` script that invokes the unavailable `pl-pkg` executable.
- Retains artifact generation through `block-tools software build` in the existing build and packaging flows.
- Adds a patch changeset for `@platforma-open/milaboratories.mixcr-scfv-clonotyping.assemble-scfv`.
- Important touched terms:
  - `prepublish`: A package-manager lifecycle script run during publication; the obsolete `pl-pkg prepublish` hook is removed.
  - `pl-pkg`: The former `@platforma-sdk/package-builder` CLI; its stale invocation is removed because that dependency is no longer present.
  - `block-tools software build`: The current software artifact build and push command; it remains the active implementation used by `build` and `do-pack`.
  - `do-pack`: The packaging script that rebuilds the software, creates a tarball, and renames it to `package.tgz`; its behavior is unchanged.
  - Changeset: Release metadata describing package version impact; a patch release entry is added for the affected assembly package.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the removed hook references an unavailable legacy CLI while current build and packaging paths already generate software artifacts with block-tools.

The change eliminates the failing `pl-pkg prepublish` invocation without removing artifact generation from the repository’s release build or `do-pack` pipeline, and no actionable regression remains.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/package.json | Removes a broken legacy publication hook while preserving the current block-tools build and packaging commands. |
| .changeset/fix-stale-prepublish-script.md | Adds accurate patch-release metadata explaining why the obsolete lifecycle script was removed. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove stale pl-pkg prepublish scri..."](https://github.com/platforma-open/mixcr-scfv-clonotyping/commit/1e5fa485895750ecff6911dce87bf22605b84d25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46956050)</sub>

<!-- /greptile_comment -->