### PR TITLE
MILAB-6723: bound cohort-scaled aggregation requests to one node's capacity

### DIFF
--- a/.changeset/clamp-cohort-aggregation-resources.md
+++ b/.changeset/clamp-cohort-aggregation-resources.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow': patch
+---
+
+Bound cohort-scaled aggregation resource requests to one node's capacity.

--- a/.changeset/clamp-cohort-aggregation-resources.md
+++ b/.changeset/clamp-cohort-aggregation-resources.md
@@ -5,6 +5,6 @@
 Clonotype aggregation requests at most 62 CPU and 256 GiB.
 
 The request scaled by one CPU and one GiB per sample with no upper bound, so a cohort
-past 62 samples asked for more CPU than the largest available node has. Such a job waits
-for capacity that cannot exist rather than failing, while still holding its queue quota.
+past 62 samples asked for more CPU than the largest available node has. Such a request fits on
+no node, so the job stays Pending indefinitely rather than failing.
 Cohorts of 62 samples or fewer request exactly what they did before.

--- a/.changeset/clamp-cohort-aggregation-resources.md
+++ b/.changeset/clamp-cohort-aggregation-resources.md
@@ -2,4 +2,9 @@
 '@platforma-open/milaboratories.mixcr-scfv-clonotyping.workflow': patch
 ---
 
-Bound cohort-scaled aggregation resource requests to one node's capacity.
+Clonotype aggregation requests at most 62 CPU and 256 GiB.
+
+The request scaled by one CPU and one GiB per sample with no upper bound, so a cohort
+past 62 samples asked for more CPU than the largest available node has. Such a job waits
+for capacity that cannot exist rather than failing, while still holding its queue quota.
+Cohorts of 62 samples or fewer request exactly what they did before.

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -8,7 +8,8 @@
     "build": "shx rm -rf dist && pl-tengo build",
     "format": "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
-    "check": "pl-tengo check"
+    "check": "pl-tengo check",
+    "test": "pl-tengo test"
   },
   "dependencies": {
     "@platforma-open/milaboratories.mixcr-scfv-clonotyping.assemble-scfv": "workspace:*",

--- a/workflow/src/agg-clones.tpl.tengo
+++ b/workflow/src/agg-clones.tpl.tengo
@@ -3,7 +3,7 @@ self := import("@platforma-sdk/workflow-tengo:tpl")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 units := import("@platforma-sdk/workflow-tengo:units")
 pt := import("@platforma-sdk/workflow-tengo:pt")
-math := import("math")
+aggRes := import(":aggregate-resources")
 json := import("json")
 
 self.defineOutputs("tsv")
@@ -54,10 +54,11 @@ self.body(func(inputs) {
 	addSchema(mainAbundanceColumnUnnormalized, "String")
 	addSchema("clonotypeKey", "String")
 
+	res := aggRes.forSamples(numberOfSamples, { floorMemGB: 64, floorCpu: 32 })
 	wf := pt.workflow().
 		inMediumQueue().
-		mem(int(math.max(numberOfSamples, 64)) * units.GiB).
-		cpu(int(math.max(numberOfSamples, 32)))
+		mem(res.memGB * units.GiB).
+		cpu(res.cpu)
 
 	dataFrames := []
 	for sKey, inputFile in inputMap {

--- a/workflow/src/aggregate-resources.lib.tengo
+++ b/workflow/src/aggregate-resources.lib.tengo
@@ -1,0 +1,39 @@
+// Sample-count-scaled resource sizing for the cross-sample aggregation ptabler runs.
+// Every aggregate-* template concatenates one frame per sample before the groupBy,
+// so peak memory grows with cohort size — but the request must still fit one node.
+//
+// Upper bounds, and why these numbers:
+//   cpu    62  largest allocatable vCPU on the biggest AWS preset. Above this the
+//              job is silently unschedulable while still holding Kueue quota.
+//   mem   256  the shipped Helm chart's maxJobResources ceiling for a single job.
+//
+// These are deliberately the NO-REGRESSION caps: below them nothing changes, and
+// above them jobs that previously could not be scheduled at all now run. Tightening
+// them to save money is a separate, measurement-gated change — not this one.
+//
+// Clamp order matters: min(cap, max(floor, n)), so a floor above the cap is still
+// capped. The reverse, max(floor, min(cap, n)), would let a large floor through.
+
+math := import("math")
+
+// forSamples(numberOfSamples, opts) -> { memGB, cpu }
+//   floorMemGB  memory floor in GiB  (pass the call site's existing floor)
+//   floorCpu    cpu floor in cores   (pass the call site's existing floor)
+//   maxMemGB    upper clamp on memory (default 256)
+//   maxCpu      upper clamp on cpu    (default 62)
+forSamples := func(numberOfSamples, ...opts) {
+	o := len(opts) == 1 ? opts[0] : {}
+	floorMemGB := is_undefined(o.floorMemGB) ? 64 : o.floorMemGB
+	floorCpu := is_undefined(o.floorCpu) ? 32 : o.floorCpu
+	maxMemGB := is_undefined(o.maxMemGB) ? 256 : o.maxMemGB
+	maxCpu := is_undefined(o.maxCpu) ? 62 : o.maxCpu
+
+	return {
+		memGB: int(math.min(maxMemGB, math.max(floorMemGB, numberOfSamples))),
+		cpu: int(math.min(maxCpu, math.max(floorCpu, numberOfSamples)))
+	}
+}
+
+export {
+	forSamples: forSamples
+}

--- a/workflow/src/aggregate-resources.lib.tengo
+++ b/workflow/src/aggregate-resources.lib.tengo
@@ -3,8 +3,8 @@
 // so peak memory grows with cohort size — but the request must still fit one node.
 //
 // Upper bounds, and why these numbers:
-//   cpu    62  largest allocatable vCPU on the biggest AWS preset. Above this the
-//              job is silently unschedulable while still holding Kueue quota.
+//   cpu    62  largest allocatable vCPU on the biggest AWS preset. A request above
+//              this fits no node, so the job stays Pending rather than failing.
 //   mem   256  the shipped Helm chart's maxJobResources ceiling for a single job.
 //
 // These are deliberately the NO-REGRESSION caps: below them nothing changes, and above

--- a/workflow/src/aggregate-resources.lib.tengo
+++ b/workflow/src/aggregate-resources.lib.tengo
@@ -7,9 +7,9 @@
 //              job is silently unschedulable while still holding Kueue quota.
 //   mem   256  the shipped Helm chart's maxJobResources ceiling for a single job.
 //
-// These are deliberately the NO-REGRESSION caps: below them nothing changes, and
-// above them jobs that previously could not be scheduled at all now run. Tightening
-// them to save money is a separate, measurement-gated change — not this one.
+// These are deliberately the NO-REGRESSION caps: below them nothing changes, and above
+// them jobs that could never be scheduled now run. Tightening them to save money is a
+// separate, measurement-gated change.
 //
 // Clamp order matters: min(cap, max(floor, n)), so a floor above the cap is still
 // capped. The reverse, max(floor, min(cap, n)), would let a large floor through.

--- a/workflow/src/aggregate-resources.test.tengo
+++ b/workflow/src/aggregate-resources.test.tengo
@@ -1,0 +1,27 @@
+test := import("@platforma-sdk/workflow-tengo:test")
+ar := import(":aggregate-resources")
+
+_MAX_CPU := 62
+_MAX_MEM_GB := 256
+
+_SAMPLE_COUNTS := [1, 2, 3, 10, 32, 62, 63, 64, 100, 400, 1000, 2000]
+
+TestNeverExceedsNodeCapacity := func() {
+	for n in _SAMPLE_COUNTS {
+		r := ar.forSamples(n, { floorMemGB: 64, floorCpu: 32 })
+		test.isTruef(r.cpu <= _MAX_CPU,
+			"cpu %d exceeds %d allocatable vCPU at %d samples", r.cpu, _MAX_CPU, n)
+		test.isTruef(r.memGB <= _MAX_MEM_GB,
+			"memGB %d exceeds the %d GiB chart ceiling at %d samples", r.memGB, _MAX_MEM_GB, n)
+	}
+}
+
+TestPreservesTodaysValuesBelowTheCap := func() {
+	o := { floorMemGB: 64, floorCpu: 32 }
+	test.isEqual(64, ar.forSamples(1, o).memGB)
+	test.isEqual(32, ar.forSamples(1, o).cpu)
+	test.isEqual(100, ar.forSamples(100, o).memGB)
+	test.isEqual(62, ar.forSamples(62, o).cpu)
+	test.isEqual(256, ar.forSamples(400, o).memGB)
+	test.isEqual(62, ar.forSamples(400, o).cpu)
+}


### PR DESCRIPTION
## What

Clonotype aggregation sized both memory and CPU from the sample count with **no upper bound**:

```go
mem(int(math.max(numberOfSamples, 64)) * units.GiB).
cpu(int(math.max(numberOfSamples, 32)))
```

Against 62 allocatable vCPU on the largest AWS preset, the CPU term crosses node capacity at **exactly 63 samples**. Past that the request fits on no node, so the pod stays Pending rather than failing — it does not error, it simply never runs. Nobody has hit it only because no cohort that large has been run through this block yet.

`max_job_cpu = 62` is from the AWS preset definitions (r7i.16xlarge allocatable minus DaemonSet overhead and safety margin); `256Gi` is the `maxJobResources` memory ceiling in the deployment values. Note those two ceilings come from different places and are not a single number — the same values file sets `maxJobResources.cpu: 64`, above the 62 the nodes actually provide, so 62 is the binding constraint for CPU.

## Change

The arithmetic moves into `aggregate-resources.lib.tengo`, which clamps both dimensions:

```go
memGB: int(math.min(maxMemGB, math.max(floorMemGB, numberOfSamples))),
cpu:   int(math.min(maxCpu,   math.max(floorCpu,   numberOfSamples)))
```

The call site becomes:

```go
res := aggRes.forSamples(numberOfSamples, { floorMemGB: 64, floorCpu: 32 })
wf := pt.workflow().
    inMediumQueue().
    mem(res.memGB * units.GiB).
    cpu(res.cpu)
```

**Where the caps come from.** 62 vCPU is the largest schedulable unit on the biggest AWS preset; 256 GiB is the shipped Helm chart's `maxJobResources` ceiling for a single job. A request above either is silently unschedulable.

**They are deliberately no-regression caps.** Below them nothing changes; above them, jobs that previously could never be scheduled now run. No cohort that works today can receive *less* than it gets today, so this cannot introduce an OOM. Tightening them to reduce cost is a separate, measurement-gated change and explicitly out of scope here.

**Clamp order matters.** It is `min(cap, max(floor, n))`. The reverse would let a floor above the cap through, which is itself an unschedulable request.

## Tests

`aggregate-resources.test.tengo` sweeps 1 to 2000 samples and asserts both bounds hold, plus that below-cap values are unchanged from the previous `max(n, floor)` behaviour — 64 GiB / 32 cpu at one sample, 100 GiB at 100 samples, 62 cpu at 62 samples, and the caps binding at 400.

The cliff was mutation-verified rather than assumed: removing the clamps makes the property test fail with `cpu 63 exceeds 62 allocatable vCPU at 63 samples`. That exact figure reproduced independently in each of the sibling repos carrying this change.

One earlier claim has been withdrawn. An earlier revision of this body and changeset said such a job holds Kueue quota while it waits. That is wrong: an inadmissible Kueue workload is never admitted, so it reserves no quota, and no live deployment sets `queueingStrategy`, so the default `BestEffortFIFO` applies and it does not block later workloads either. The wording now states only the part that is verifiable — a request exceeding every node's allocatable capacity cannot be placed, so it stays Pending.

`pnpm exec pl-tengo test`, `pl-tengo check`, and `pnpm run build:dev-no-software` all pass.

## Notes for review

The helper is **duplicated per repo, on purpose.** A lib in one block repo cannot be imported by another, there is no shared block-level library, and publishing one into the SDK was out of scope. `synthetic-repertoire-profiler` already does exactly this and was the model. Every copy is byte-identical — verified by checksum — so a future change to the arithmetic must be propagated deliberately rather than drifting in one place.

This template carries no `//tengo:hash_override`, so no UUID bump was needed here. One sibling repo's template does, and that PR bumps it.

The block's other `mem()` call sites are untouched: this change is scoped to the cross-sample aggregation, which is the only site whose request scales with cohort size.
