### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# MiXCR scFv Alignment
+
+Clonotype single-chain variable fragment libraries. This Platforma block uses MiXCR to process scFv sequencing data, separating each construct into its VH chain, VL chain, and synthetic linker, then assembling and quantifying unique scFv clonotypes — the first analysis step for phage and yeast display antibody discovery.
+
+Open-source analysis block for Platforma, the biologics discovery platform by MiLaboratories. For the full no-code workflow, see [platforma.bio](https://platforma.bio/).
+
+## What it does
+
+A scFv is one polypeptide containing two variable domains joined by an engineered linker. That makes it awkward for standard clonotyping: aligning the whole construct against germline references confuses the two domains, and the linker belongs to neither.
+
+This block handles the construct as a construct. It identifies the three functional elements — the variable heavy chain, the variable light chain, and the linker peptide between them — and clonotypes each domain on its own terms, so a clonotype is a specific VH/VL pairing rather than an approximate whole-read match.
+
+Because scFv library designs vary so widely, the block is correspondingly configurable. You supply the **linker nucleotide sequence** and, where present, a **hinge region sequence**, and set the **construct building order** so the block knows how your VH, linker, and VL are arranged. Each chain gets its own **assembling feature**, so heavy and light can be clonotyped at different granularities, and its own **tag pattern** for UMI and barcode extraction. Error correction strength is configurable, as are custom reference libraries for engineered scaffolds the germline references do not cover, and CPU and memory for both the MiXCR and the scFv assembly stages.
+
+Outputs include the full scFv sequence alongside the separated heavy and light chain sequences, so downstream analysis can work at whichever level the question needs. A QC report table and per-sample reports show alignment and assembly quality across the library.
+
+## Inputs & outputs
+
+* **Input:** raw sequencing data from [Samples & Data](https://github.com/platforma-open/samples-and-data), plus your construct description — linker sequence, optional hinge sequence, and construct building order.
+* **Output:** a quantified scFv clonotype dataset with the full construct sequence and separated VH and VL sequences and abundances, consumable by downstream Platforma blocks; a QC report table; per-sample reports and logs.
+
+## Specifications
+
+| | |
+|---|---|
+| Block title in app | MiXCR scFv Alignment |
+| Engine | [MiXCR](https://mixcr.com/) |
+| Construct handling | Separates VH chain, VL chain, and synthetic linker; configurable construct building order |
+| Construct parameters | Linker nucleotide sequence, hinge region nucleotide sequence |
+| Per-chain settings | Independent assembling feature and tag pattern for heavy and light |
+| UMI / barcodes | Per-chain MiXCR tag patterns |
+| Reference library | Built-in germline references or a custom library |
+| Compute | Independent CPU and memory settings for the MiXCR and scFv assembly stages |
+| Outputs | Full scFv sequence, heavy and light chain sequences, abundances, QC report table |
+
+## Use cases
+
+* **Phage display libraries:** clonotype scFv libraries from panning campaigns, with the VH/VL pairing preserved.
+* **Yeast display:** process scFv libraries from surface-display selections.
+* **Library diversity assessment:** quantify how many distinct VH/VL pairings a library actually contains.
+* **Selection tracking:** feed clonotypes into [Enrichment Analysis](https://github.com/platforma-open/clonotype-enrichment) to see which scFvs enriched across rounds.
+* **Paired-chain downstream analysis:** carry the VH/VL pairing into clustering, embedding, developability, and lead selection.
+* **Construct QC:** confirm that reads match the intended construct layout before drawing conclusions about the library.
+
+## FAQ
+
+### Why does scFv data need a dedicated block?
+
+Because an scFv is two variable domains and a synthetic linker in a single read. Standard clonotyping treats a read as one receptor chain, which conflates the domains and cannot account for the linker. This block resolves the three elements first, then clonotypes each domain properly.
+
+### What do I need to know about my construct?
+
+The linker nucleotide sequence, the hinge region sequence if your design has one, and the order in which VH, linker, and VL appear. Those three facts let the block parse the construct correctly; getting them wrong is the usual cause of poor alignment rates.
+
+### Can heavy and light chains be clonotyped differently?
+
+Yes. Each chain has its own assembling feature, so you can clonotype one at full variable region and the other at CDR3 if that is what your amplicon supports.
+
+### How are UMIs handled?
+
+Through per-chain MiXCR tag patterns, so a design that places barcodes differently for each chain is supported. Abundances are then counted per unique molecule rather than per read.
+
+### What comes out — the whole construct or the chains?
+
+Both. The full scFv sequence is reported alongside the separated heavy and light chain sequences, so downstream analysis can operate on the construct, on either chain, or on the pairing.
+
+
+## Citation
+
+MiXCR is developed by MiLaboratories Inc. If you use this block in your research, please cite:
+
+> Bolotin, D. A., Poslavsky, S., Mitrophanov, I., Shugay, M., Mamedov, I. Z., Putintseva, E. V., & Chudakov, D. M. (2015). MiXCR: software for comprehensive adaptive immunity profiling. *Nature Methods* **12**(5), 380–381. [https://doi.org/10.1038/nmeth.3364](https://doi.org/10.1038/nmeth.3364)
+
+## Documentation
+
+Step-by-step guide: [Annotating scFv Libraries](https://docs.platforma.bio/guides/antibody-discovery/scFv-clonotyping/)
+
+## Part of the Platforma ecosystem
+
+This block is part of [Platforma](https://platforma.bio/) by [MiLaboratories](https://github.com/milaboratory), built on [MiXCR](https://mixcr.com/). Explore the other open-source blocks at [github.com/platforma-open](https://github.com/platforma-open) and the docs for antibody discovery at [docs.platforma.bio/biology-guides/antibody-discovery](https://docs.platforma.bio/biology-guides/antibody-discovery/).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the repository's first README, documenting the scFv clonotyping workflow, configuration, outputs, use cases, FAQ, citation, and ecosystem links. Important touched terms:
- **scFv** — a single-chain variable fragment containing paired variable domains joined by a linker; newly introduced as the block's primary analyzed construct.
- **VH / VL** — variable heavy and variable light antibody domains; newly documented as independently aligned and clonotyped while preserving their pairing.
- **Synthetic linker** — the engineered sequence joining VH and VL; newly documented as a construct input used to separate the domains.
- **Hinge region** — an optional construct segment when present in the library design; newly documented as configurable sequence input.
- **Construct building order** — whether heavy or light appears first in the construct; newly documented as necessary parsing configuration.
- **Assembling feature** — the sequence region used to define clonotypes; newly documented as independently configurable for each chain.
- **Tag pattern / UMI** — MiXCR patterns used to extract barcodes and molecular identifiers; newly documented, although the molecule-count description needs qualification.
- **Custom reference library** — engineered V/J references used instead of built-in germline references; newly documented as supported configuration.
- **QC report** — alignment and assembly quality summaries; newly documented as an output.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only PR appears safe to merge after correcting the omitted required inputs and qualifying molecule-based abundance as UMI-dependent.

The README accurately describes most capabilities, but its explicit input list is incomplete and its abundance explanation can cause non-UMI read counts to be interpreted as molecule counts.

**Files Needing Attention:** README.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds comprehensive block documentation, with two non-blocking accuracy gaps in the required-input list and UMI abundance explanation. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20platforma-open%2Fmixcr-scfv-clonotyping%20PR%20%2374%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=platforma-open%2Fmixcr-scfv-clonotyping&pr=74&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A24%0A**Required%20inputs%20are%20incomplete**%0A%0AThe%20explicit%20input%20list%20omits%20species%20for%20the%20default%20built-in-reference%20mode%20and%20the%20required%20heavy%20and%20light%20tag%20patterns.%20A%20user%20who%20supplies%20every%20listed%20input%20can%20still%20encounter%20%60Species%20is%20required%60%2C%20%60Heavy%20tag%20pattern%20is%20required%60%2C%20or%20%60Light%20tag%20pattern%20is%20required%60%20validation%20errors.%0A%0A%23%23%23%20Issue%202%0AREADME.md%3A61%0A**Molecule%20counting%20is%20conditional**%0A%0AUnique-molecule%20abundance%20applies%20only%20to%20UMI-enabled%20analyses%3B%20non-UMI%20runs%20use%20read%20counts%20as%20their%20primary%20abundance.%20The%20unconditional%20wording%20can%20cause%20users%20to%20interpret%20read%20counts%20as%20molecule%20counts%20and%20draw%20incorrect%20quantitative%20conclusions.%0A%0A%60%60%60suggestion%0AThrough%20per-chain%20MiXCR%20tag%20patterns%2C%20so%20a%20design%20that%20places%20barcodes%20differently%20for%20each%20chain%20is%20supported.%20For%20UMI-enabled%20analyses%2C%20abundances%20are%20counted%20per%20unique%20molecule%3B%20analyses%20without%20UMIs%20use%20read%20counts.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=platforma-open%2Fmixcr-scfv-clonotyping&pr=74&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:24
**Required inputs are incomplete**

The explicit input list omits species for the default built-in-reference mode and the required heavy and light tag patterns. A user who supplies every listed input can still encounter `Species is required`, `Heavy tag pattern is required`, or `Light tag pattern is required` validation errors.

### Issue 2
README.md:61
**Molecule counting is conditional**

Unique-molecule abundance applies only to UMI-enabled analyses; non-UMI runs use read counts as their primary abundance. The unconditional wording can cause users to interpret read counts as molecule counts and draw incorrect quantitative conclusions.

```suggestion
Through per-chain MiXCR tag patterns, so a design that places barcodes differently for each chain is supported. For UMI-enabled analyses, abundances are counted per unique molecule; analyses without UMIs use read counts.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Create README.md"](https://github.com/platforma-open/mixcr-scfv-clonotyping/commit/b641bd3df631d152358d274b26bb8dbb14bef8e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56615564)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->